### PR TITLE
Nagios and certification directory enhancemens

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,20 @@ ssl-cert-check is a Bourne shell script that can be used to report on expiring S
 # Usage:
 <pre>
 $ ./ssl-cert-check
-Usage: ./ssl-cert-check [ -e email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-v]
-       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c certificate file ] }
+Usage: ./ssl-cert-check [ -e email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v]
+       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }"
 
   -a                : Send a warning message through E-mail
   -b                : Will not print header
   -c cert file      : Print the expiration date for the PEM or PKCS12 formatted certificate in cert file
+  -d cert directory : Print the expiration date for the PEM or PKCS12 formatted certificates in cert directory
   -e E-mail address : E-mail address to send expiration notices
   -f cert file      : File with a list of FQDNs and ports
   -h                : Print this screen
   -i                : Print the issuer of the certificate
   -k password       : PKCS12 file password
   -n                : Run as a Nagios plugin
+  -N                : Run as a Nagios plugin and output one line summary (implies -n, requires -f or -d)
   -p port           : Port to connect to (interactive mode)
   -s commmon name   : Server to connect to (interactive mode)
   -t type           : Specify the certificate type
@@ -27,10 +29,10 @@ Usage: ./ssl-cert-check [ -e email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i
 </pre>
 
 # Examples:
-<pre>
 
 Print the expiration times for one or more certificates listed in ssldomains:
 
+<pre>
 $ ssl-cert-check -f ssldomains
 Host                                            Status       Expires      Days Left
 ----------------------------------------------- ------------ ------------ ----------
@@ -39,6 +41,17 @@ mail.prefetch.net:993                           Valid        Jun 20 2006  246
 gmail.google.com:443                            Valid        Jun 7 2006   233
 www.sun.com:443                                 Valid        May 11 2009  1302
 www.spotch.com:443                              Connection refused Unknown Unknown
+</pre>
+
+Check all certificates with file pattern "/etc/haproxy/ssl/\*.pem"
+
+<pre>
+$ ssl-cert-check -d "/etc/haproxy/ssl/\*.pem"
+Host                                            Status       Expires      Days
+----------------------------------------------- ------------ ------------ ----
+FILE:/etc/haproxy/ssl/example1.org.pem      Valid        Jan 6 2017   78                                 
+FILE:/etc/haproxy/ssl/example2.org.pem      Valid        Jan 1 2017   73                                 
+FILE:/etc/haproxy/ssl/example3.org.pem      Valid        Jan 6 2017   78                                 
 </pre>
 
 Send an e-mail to admin@prefetch.net if a domain listed in ssldomains will expire in the next 60-days:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ www.spotch.com:443                              Connection refused Unknown Unkno
 Check all certificates with file pattern "/etc/haproxy/ssl/\*.pem"
 
 <pre>
-$ ssl-cert-check -d "/etc/haproxy/ssl/\*.pem"
+$ ssl-cert-check -d "/etc/haproxy/ssl/*.pem"
 Host                                            Status       Expires      Days
 ----------------------------------------------- ------------ ------------ ----
 FILE:/etc/haproxy/ssl/example1.org.pem      Valid        Jan 6 2017   78                                 

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -17,12 +17,13 @@
 #  - Set RETCODE to 3 (unknown) if a certificate file does not exist -- Marcel Pennewiss
 #  - Add a "-d" option to specify a directory or file mask pattern -- Marcel Pennewiss
 #  - Add a "-N" option to create summarized Nagios output -- Marcel Pennewiss
+#  - Cleaned up many formatting -- Marcel Pennewiss
 #
 # Version 3.29
 #  - Add the openssl -servername flag if it shows up in help.
 #
 # Version 3.28
-#  - Added  a DEBUG option to assist with debugging folks who use the script
+#  - Added a DEBUG option to assist with debugging folks who use the script
 #
 # Version 3.27
 #  - Allow white spaces to exist in the certificate file list
@@ -59,7 +60,7 @@
 #   - Added check to verify the certificate retrieved is valid
 #
 # Version 3.18
-#   - Add support for connecting to FTP servers -- Paul A Sand 
+#   - Add support for connecting to FTP servers -- Paul A Sand
 #
 # Version 3.17
 #   - Add support for connecting to imap servers -- Joerg Pareigis
@@ -68,12 +69,12 @@
 #   - Add support for connecting to the mail sbmission port -- Luis E. Munoz
 #
 # Version 3.15
-#   - Adjusted the file checking logic to use the correct certificate -- Maciej Szudejko 
+#   - Adjusted the file checking logic to use the correct certificate -- Maciej Szudejko
 #   - Add sbin to the default search paths for OpenBSD compatibility -- Alex Popov
 #   - Use cut instead of substring processing to ensure compatibility -- Alex Popov
 #
 # Version 3.14
-#   - Fixed the Common Name parser to handle DN's where the CN is not the last item 
+#   - Fixed the Common Name parser to handle DN's where the CN is not the last item
 #     eg. EmailAddr -- Jason Brothers
 #   - Added the ability to grab the serial number -- Jason Brothers
 #   - Added the "-b" option to print results without a header -- Jason Brothers
@@ -82,7 +83,7 @@
 # Version 3.13
 #   - Updated the subject line to include the hostname as well as
 #     the common name embedded in the X509 certificate (if it's
-#     available) -- idea proposed by Mike Burns 
+#     available) -- idea proposed by Mike Burns
 #
 #  Version 3.12
 #   - Updated the license to allow redistribution and modification
@@ -103,7 +104,7 @@
 #    - Cleaned up the formatting
 #
 #  Version 3.7
-#    - Fixed bug in NAGIOS tests -- Ben Allen 
+#    - Fixed bug in NAGIOS tests -- Ben Allen
 #
 #  Version 3.6
 #    - Added support for certificates stored in PKCS#12 databases -- Ken Gallo
@@ -125,9 +126,9 @@
 #
 #  Version 3.3
 #   - Added common name from X.509 certificate file to E-mail body / header -- Doug Curtis
-#   - Fixed several documentation errors 
+#   - Fixed several documentation errors
 #   - Use mktemp to create temporary files
-#   - Convert printf, sed and awk to variables 
+#   - Convert printf, sed and awk to variables
 #   - Check for printf, sed, awk and mktemp binaries
 #   - Add additional logic to make sure mktemp returned a valid temporary file
 #
@@ -140,7 +141,7 @@
 #   - Removed extra spacing at end of script
 #
 #  Version 3.0
-#   - Added "-i" option to print certificate issuer  
+#   - Added "-i" option to print certificate issuer
 #   - Removed $0 from Subject line of outbound e-mails
 #   - Fixed some typographical errors
 #   - Removed redundant "-b" option
@@ -148,17 +149,17 @@
 #  Version 2.0
 #    - Fixed an issue with e-mails formatting incorrectly
 #    - Added additional space to host column -- Darren-Perot Spruell
-#    - Replaced GNU date dependency with CHRIS F. A. JOHNSON's 
-#      date2julian shell function. This routine can be found on 
-#      page 170 of Chris's book "Shell Scripting Recipes: A 
-#      Problem-Solution Approach," ISBN #1590594711. Julian function 
+#    - Replaced GNU date dependency with CHRIS F. A. JOHNSON's
+#      date2julian shell function. This routine can be found on
+#      page 170 of Chris's book "Shell Scripting Recipes: A
+#      Problem-Solution Approach," ISBN #1590594711. Julian function
 #      was created based on a post to comp.unix.shell by Tapani Tarvainen.
 #    - Cleaned up function descriptions
 #    - Removed several lines of redundant code
 #    - Adjusted the help message
-#      
+#
 #   Version 1.1
-#    - Added "-c" flag to report expiration status of a PEM encoded 
+#    - Added "-c" flag to report expiration status of a PEM encoded
 #      certificate -- Hampus Lundqvist
 #    - Updated the prints messages to display the reason a connection
 #      failed (connection refused, connection timeout, bad cert, etc)
@@ -174,12 +175,12 @@
 #
 # Last Updated: 20-10-2016
 #
-# Purpose: 
+# Purpose:
 #  ssl-cert-check checks to see if a digital certificate in X.509 format
 #  has expired. ssl-cert-check can be run in interactive and batch mode,
 #  and provides facilities to alarm if a certificate is about to expire.
 #
-# License: 
+# License:
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
@@ -192,8 +193,8 @@
 #
 # Requirements:
 #   Requires openssl
-# 
-# Installation: 
+#
+# Installation:
 #   Copy the shell script to a suitable location
 #
 # Tested platforms:
@@ -205,11 +206,11 @@
 #  -- Centos Linux 3, 4, 5 & 6 using /bin/bash
 #  -- Redhat Enterprise Linux 3, 4, 5 & 6 using /bin/bash
 #  -- Gentoo using /bin/bash
-# 
+#
 # Usage:
-#  Refer to the usage() sub-routine, or invoke ssl-cert-check 
+#  Refer to the usage() sub-routine, or invoke ssl-cert-check
 #  with the "-h" option.
-# 
+#
 # Examples:
 #   Please refer to the following site for documentation and examples:
 #   http://prefetch.net/articles/checkcertificate.html
@@ -220,7 +221,7 @@ export PATH
 # Who to page when an expired certificate is detected (cmdline: -e)
 ADMIN="root"
 
-# Number of days in the warning threshhold  (cmdline: -x)
+# Number of days in the warning threshhold (cmdline: -x)
 WARNDAYS=30
 
 # If QUIET is set to TRUE, don't print anything on the console (cmdline: -q)
@@ -304,19 +305,19 @@ umask 077
 #############################################################################
 date2julian() {
 
-    if [ "${1}" != "" ] && [ "${2}" != ""  ] && [ "${3}" != "" ]
+    if [ "${1}" != "" ] && [ "${2}" != "" ] && [ "${3}" != "" ]
     then
-        ## Since leap years add aday at the end of February, 
+        ## Since leap years add aday at the end of February,
         ## calculations are done from 1 March 0000 (a fictional year)
         d2j_tmpmonth=$((12 * ${3} + ${1} - 3))
-        
+
         ## If it is not yet March, the year is changed to the previous year
         d2j_tmpyear=$(( ${d2j_tmpmonth} / 12))
-        
+
         ## The number of days from 1 March 0000 is calculated
-        ## and the number of days from 1 Jan. 4713BC is added 
+        ## and the number of days from 1 Jan. 4713BC is added
         echo $(( (734 * ${d2j_tmpmonth} + 15) / 24
-                 - 2 * ${d2j_tmpyear} + ${d2j_tmpyear}/4 
+                 - 2 * ${d2j_tmpyear} + ${d2j_tmpyear}/4
                  - ${d2j_tmpyear}/100 + ${d2j_tmpyear}/400 + $2 + 1721119 ))
     else
         echo 0
@@ -328,7 +329,7 @@ date2julian() {
 # Arguments:
 #   $1 -> Month name (e.g., Sep)
 #############################################################################
-getmonth() 
+getmonth()
 {
     case ${1} in
         Jan) echo 1 ;;
@@ -343,7 +344,7 @@ getmonth()
         Oct) echo 10 ;;
         Nov) echo 11 ;;
         Dec) echo 12 ;;
-          *) echo  0 ;;
+          *) echo 0 ;;
     esac
 }
 
@@ -353,9 +354,9 @@ getmonth()
 #   $1 -> Date #1
 #   $2 -> Date #2
 #############################################################################
-date_diff() 
+date_diff()
 {
-    if [ "${1}" != "" ] &&  [ "${2}" != "" ]
+    if [ "${1}" != "" ] && [ "${2}" != "" ]
     then
         echo $((${2} - ${1}))
     else
@@ -367,27 +368,27 @@ date_diff()
 # Purpose: Print a line with the expiraton interval
 # Arguments:
 #   $1 -> Hostname
-#   $2 -> TCP Port 
+#   $2 -> TCP Port
 #   $3 -> Status of certification (e.g., expired or valid)
 #   $4 -> Date when certificate will expire
-#   $5 -> Days left until the certificate will expire 
+#   $5 -> Days left until the certificate will expire
 #   $6 -> Issuer of the certificate
 #####################################################################
-prints() 
+prints()
 {
     if [ "${NAGIOSSUMMARY}" == "TRUE" ]
     then
         return
     fi
 
-    if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${VALIDATION}" != "TRUE" ] 
+    if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]
     then
         MIN_DATE=$(echo $4 | ${AWK} '{ print $1, $2, $4 }')
         if [ "${NAGIOS}" == "TRUE" ]
         then
-            ${PRINTF} "%-35s %-17s %-8s %-11s %-4s %-30s\n" "$1:$2" "$6" "$3" "$MIN_DATE" \|days="$5" 
+            ${PRINTF} "%-35s %-17s %-8s %-11s %-4s %-30s\n" "$1:$2" "$6" "$3" "$MIN_DATE" \|days="$5"
         else
-            ${PRINTF} "%-35s %-17s %-8s %-11s %-4s %-30s\n" "$1:$2" "$6" "$3" "$MIN_DATE" "$5" 
+            ${PRINTF} "%-35s %-17s %-8s %-11s %-4s %-30s\n" "$1:$2" "$6" "$3" "$MIN_DATE" "$5"
         fi
     elif [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${VALIDATION}" == "TRUE" ]
     then
@@ -398,10 +399,10 @@ prints()
         MIN_DATE=$(echo $4 | ${AWK} '{ print $1, $2, $4 }')
         if [ "${NAGIOS}" == "TRUE" ]
         then
-            ${PRINTF} "%-47s %-12s %-12s %-4s %-30s\n" "$1:$2" "$3" "$MIN_DATE" \|days="$5" 
+            ${PRINTF} "%-47s %-12s %-12s %-4s %-30s\n" "$1:$2" "$3" "$MIN_DATE" \|days="$5"
         else
-            ${PRINTF} "%-47s %-12s %-12s %-4s %-30s\n" "$1:$2" "$3" "$MIN_DATE" "$5" 
-        fi  
+            ${PRINTF} "%-47s %-12s %-12s %-4s %-30s\n" "$1:$2" "$3" "$MIN_DATE" "$5"
+        fi
     elif [ "${QUIET}" != "TRUE" ] && [ "${VALIDATION}" == "TRUE" ]
     then
         ${PRINTF} "%-35s %-35s %-32s\n" "$1:$2" "$7" "$8"
@@ -414,29 +415,29 @@ prints()
 # Arguments:
 #   None
 ####################################################
-print_heading() 
+print_heading()
 {
     if [ "${NOHEADER}" != "TRUE" ]
-    then 
-       if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]
-       then
-           ${PRINTF} "\n%-35s %-17s %-8s %-11s %-4s\n" "Host" "Issuer" "Status" "Expires" "Days"
-           echo "----------------------------------- ----------------- -------- ----------- ----"
+    then
+        if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]
+        then
+            ${PRINTF} "\n%-35s %-17s %-8s %-11s %-4s\n" "Host" "Issuer" "Status" "Expires" "Days"
+            echo "----------------------------------- ----------------- -------- ----------- ----"
 
-       elif [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" == "TRUE" ]
-       then
-           ${PRINTF} "\n%-35s %-35s %-32s %-17s\n" "Host" "Common Name" "Serial #" "Issuer"
-           echo "----------------------------------- ----------------------------------- -------------------------------- -----------------"
-    
-       elif [ "${QUIET}" != "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]
-       then
-           ${PRINTF} "\n%-47s %-12s %-12s %-4s\n" "Host" "Status" "Expires" "Days" 
-           echo "----------------------------------------------- ------------ ------------ ----"
-    
-       elif [ "${QUIET}" != "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" == "TRUE" ]
-       then
-           ${PRINTF} "\n%-35s %-35s %-32s\n" "Host" "Common Name" "Serial #"
-           echo "----------------------------------- ----------------------------------- --------------------------------"
+        elif [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" == "TRUE" ]
+        then
+            ${PRINTF} "\n%-35s %-35s %-32s %-17s\n" "Host" "Common Name" "Serial #" "Issuer"
+            echo "----------------------------------- ----------------------------------- -------------------------------- -----------------"
+
+        elif [ "${QUIET}" != "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]
+        then
+            ${PRINTF} "\n%-47s %-12s %-12s %-4s\n" "Host" "Status" "Expires" "Days"
+            echo "----------------------------------------------- ------------ ------------ ----"
+
+        elif [ "${QUIET}" != "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" == "TRUE" ]
+        then
+            ${PRINTF} "\n%-35s %-35s %-32s\n" "Host" "Common Name" "Serial #"
+            echo "----------------------------------- ----------------------------------- --------------------------------"
         fi
     fi
 }
@@ -446,7 +447,7 @@ print_heading()
 # Arguments:
 #   None
 ####################################################
-print_summary() 
+print_summary()
 {
     if [ "${NAGIOSSUMMARY}" != "TRUE" ]
     then
@@ -460,7 +461,7 @@ print_summary()
     elif [ ${SUMMARY_EXPIRED} -ne 0 ]
     then
         ${PRINTF} "%s certificate(s) expired (%s:%s on %s)|days=%s\n" "${SUMMARY_EXPIRED}" "${SUMMARY_MIN_HOST}" "${SUMMARY_MIN_PORT}" "${SUMMARY_MIN_DATE}" "${SUMMARY_MIN_DIFF}"
-      
+
     elif [ ${SUMMARY_WILL_EXPIRE} -ne 0 ]
     then
         ${PRINTF} "%s certificate(s) will expire (%s:%s on %s)|days=%s\n" "${SUMMARY_WILL_EXPIRE}" "${SUMMARY_MIN_HOST}" "${SUMMARY_MIN_PORT}" "${SUMMARY_MIN_DATE}" "${SUMMARY_MIN_DIFF}"
@@ -486,9 +487,9 @@ set_returncode()
 # Arguments:
 #   $1 -> Status of certificate (0: valid, 1: will expire, 2: expired)
 #   $2 -> Hostname
-#   $3 -> TCP Port 
+#   $3 -> TCP Port
 #   $4 -> Date when certificate will expire
-#   $5 -> Days left until the certificate will expire 
+#   $5 -> Days left until the certificate will expire
 ########################################################################
 set_summary()
 {
@@ -518,10 +519,10 @@ set_summary()
 # Arguments:
 #   None
 ##########################################
-usage() 
+usage()
 {
     echo "Usage: $0 [ -e email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v]"
-    echo "       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }" 
+    echo "       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }"
     echo ""
     echo "  -a                : Send a warning message through E-mail"
     echo "  -b                : Will not print header"
@@ -565,7 +566,7 @@ check_server_status() {
     elif [ "_${2}" = "_pop3" -o "_${2}" = "_110" ]
     then
         TLSFLAG="-starttls pop3"
-    
+
     elif [ "_${2}" = "_imap" -o "_${2}" = "_143" ]
     then
         TLSFLAG="-starttls imap"
@@ -589,36 +590,36 @@ check_server_status() {
 
     echo "" | ${OPENSSL} s_client ${VER} -connect ${1}:${2} ${TLSFLAG} 2> ${ERROR_TMP} 1> ${CERT_TMP}
 
-    if ${GREP} -i  "Connection refused" ${ERROR_TMP} > /dev/null
+    if ${GREP} -i "Connection refused" ${ERROR_TMP} > /dev/null
     then
-        prints ${1} ${2} "Connection refused" "Unknown"  
+        prints ${1} ${2} "Connection refused" "Unknown"
         set_returncode 3
 
     elif ${GREP} -i "No route to host" ${ERROR_TMP} > /dev/null
     then
-        prints ${1} ${2} "No route to host" "Unknown"  
+        prints ${1} ${2} "No route to host" "Unknown"
         set_returncode 3
 
     elif ${GREP} -i "gethostbyname failure" ${ERROR_TMP} > /dev/null
     then
-        prints ${1} ${2} "Cannot resolve domain" "Unknown" 
+        prints ${1} ${2} "Cannot resolve domain" "Unknown"
         set_returncode 3
-    
+
     elif ${GREP} -i "Operation timed out" ${ERROR_TMP} > /dev/null
     then
-        prints ${1} ${2} "Operation timed out" "Unknown"  
+        prints ${1} ${2} "Operation timed out" "Unknown"
         set_returncode 3
- 
+
     elif ${GREP} -i "ssl handshake failure" ${ERROR_TMP} > /dev/null
     then
-        prints ${1} ${2} "SSL handshake failed" "Unknown"  
+        prints ${1} ${2} "SSL handshake failed" "Unknown"
         set_returncode 3
 
     elif ${GREP} -i "connect: Connection timed out" ${ERROR_TMP} > /dev/null
     then
-        prints ${1} ${2} "Connection timed out" "Unknown"  
+        prints ${1} ${2} "Connection timed out" "Unknown"
         set_returncode 3
-    
+
     else
         check_file_status ${CERT_TMP} $1 $2
     fi
@@ -653,22 +654,22 @@ check_file_status() {
         # send the informational message to /dev/null
         ${OPENSSL} pkcs12 -nokeys -in ${CERTFILE} \
                    -out ${CERT_TMP} -clcerts -password pass:${PKCSDBPASSWD} 2> /dev/null
-           
+
         # Extract the expiration date from the certificate
         CERTDATE=$(${OPENSSL} x509 -in ${CERT_TMP} -enddate -noout | \
                  ${SED} 's/notAfter\=//')
 
         # Extract the issuer from the certificate
         CERTISSUER=$(${OPENSSL} x509 -in ${CERT_TMP} -issuer -noout | \
-                    ${AWK} 'BEGIN {RS="/" } $0 ~ /^O=/ \
-                                  { print substr($0,3,17)}')
+                   ${AWK} 'BEGIN {RS="/" } $0 ~ /^O=/ \
+                                 { print substr($0,3,17)}')
 
         ### Grab the common name (CN) from the X.509 certificate
         COMMONNAME=$(${OPENSSL} x509 -in ${CERT_TMP} -subject -noout | \
                    ${SED} -e 's/.*CN=//' | \
-				   ${SED} -e 's/\/.*//')
-        
-	### Grab the serial number from the X.509 certificate
+                   ${SED} -e 's/\/.*//')
+
+        ### Grab the serial number from the X.509 certificate
         SERIAL=$(${OPENSSL} x509 -in ${CERT_TMP} -serial -noout | \
                    ${SED} -e 's/serial=//')
     else
@@ -683,8 +684,9 @@ check_file_status() {
         ### Grab the common name (CN) from the X.509 certificate
         COMMONNAME=$(${OPENSSL} x509 -in ${CERTFILE} -subject -noout -inform ${CERTTYPE} | \
                    ${SED} -e 's/.*CN=//' | \
-				   ${SED} -e 's/\/.*//')
-	### Grab the serial number from the X.509 certificate
+                   ${SED} -e 's/\/.*//')
+
+        ### Grab the serial number from the X.509 certificate
         SERIAL=$(${OPENSSL} x509 -in ${CERTFILE} -serial -noout -inform ${CERTTYPE} | \
                    ${SED} -e 's/serial=//')
     fi
@@ -715,14 +717,14 @@ check_file_status() {
             echo "The SSL certificate for ${HOST} \"(CN: ${COMMONNAME})\" will expire on ${CERTDATE}" \
                  | ${MAIL} -s "Certificate for ${HOST} \"(CN: ${COMMONNAME})\" will expire in ${WARNDAYS}-days or less" ${ADMIN}
         fi
-        prints ${HOST} ${PORT} "Expiring" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}" 
+        prints ${HOST} ${PORT} "Expiring" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
         RETCODE_LOCAL=1
 
     else
         prints ${HOST} ${PORT} "Valid" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
         RETCODE_LOCAL=0
     fi
-    
+
     set_returncode ${RETCODE_LOCAL}
     MIN_DATE=$(echo ${CERTDATE} | ${AWK} '{ print $1, $2, $4 }')
     set_summary ${RETCODE_LOCAL} ${HOST} ${PORT} "${MIN_DATE}" ${CERTDIFF}
@@ -817,7 +819,7 @@ else
 fi
 
 # Place to stash temporary files
-CERT_TMP=$($MKTEMP  /var/tmp/cert.XXXXXX)
+CERT_TMP=$($MKTEMP /var/tmp/cert.XXXXXX)
 ERROR_TMP=$($MKTEMP /var/tmp/error.XXXXXX)
 
 ### Baseline the dates so we have something to compare to
@@ -843,13 +845,13 @@ then
     check_server_status "${HOST}" "${PORT}"
     print_summary
 
-### If a file is passed to the "-f" option on the command line, check 
-### each certificate or server / port combination in the file to see if 
+### If a file is passed to the "-f" option on the command line, check
+### each certificate or server / port combination in the file to see if
 ### they are about to expire
 elif [ -f "${SERVERFILE}" ]
 then
     print_heading
-    
+
     IFS=$'\n'
     for LINE in `egrep -v '(^#|^$)' ${SERVERFILE}`
     do
@@ -870,7 +872,7 @@ then
 elif [ "${CERTFILE}" != "" ]
 then
     print_heading
-    check_file_status ${CERTFILE} "FILE"  "${CERTFILE}"
+    check_file_status ${CERTFILE} "FILE" "${CERTFILE}"
     print_summary
 
 ### Check to see if the certificates in CERTDIRECTORY are about to expire
@@ -900,7 +902,8 @@ fi
 rm -f ${CERT_TMP} ${ERROR_TMP}
 
 ### Exit with a success indicator
-if [ "${NAGIOS}" = "TRUE" ]; then
+if [ "${NAGIOS}" = "TRUE" ]
+then
     exit $RETCODE
 else
     exit 0

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -15,6 +15,7 @@
 # Version 3.30
 #  - Use highest returncode for Nagios output -- Marcel Pennewiss
 #  - Set RETCODE to 3 (unknown) if a certificate file does not exist -- Marcel Pennewiss
+#  - Add a "-d" option to specify a directory or file mask pattern -- Marcel Pennewiss
 #
 # Version 3.29
 #  - Add the openssl -servername flag if it shows up in help.
@@ -170,7 +171,7 @@
 #  Version 1.0
 #      Initial Release
 #
-# Last Updated: 01-05-2016
+# Last Updated: 20-10-2016
 #
 # Purpose: 
 #  ssl-cert-check checks to see if a digital certificate in X.509 format
@@ -250,6 +251,7 @@ OPENSSL=$(which openssl)
 PRINTF=$(which printf)
 SED=$(which sed)
 MKTEMP=$(which mktemp)
+FIND=$(which find)
 
 # Try to find a mail client
 if [ -f /usr/bin/mailx ]
@@ -442,11 +444,12 @@ set_returncode()
 usage() 
 {
     echo "Usage: $0 [ -e email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-v]"
-    echo "       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c certificate file ] }" 
+    echo "       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }"
     echo ""
     echo "  -a                : Send a warning message through E-mail"
     echo "  -b                : Will not print header"
     echo "  -c cert file      : Print the expiration date for the PEM or PKCS12 formatted certificate in cert file"
+    echo "  -d cert directory : Print the expiration date for the PEM or PKCS12 formatted certificates in cert directory"
     echo "  -e E-mail address : E-mail address to send expiration notices"
     echo "  -f cert file      : File with a list of FQDNs and ports"
     echo "  -h                : Print this screen"
@@ -648,13 +651,14 @@ check_file_status() {
 #################################
 ### Start of main program
 #################################
-while getopts abinv:e:f:c:hk:p:s:t:qx:V option
+while getopts abinv:e:f:c:d:hk:p:s:t:qx:V option
 do
     case "${option}"
     in
         a) ALARM="TRUE";;
         b) NOHEADER="TRUE";;
         c) CERTFILE=${OPTARG};;
+        d) CERTDIRECTORY=${OPTARG};;
         e) ADMIN=${OPTARG};;
         f) SERVERFILE=$OPTARG;;
         h) usage
@@ -690,11 +694,11 @@ then
     exit 1
 fi
 
-### Check to make sure a grep utility is available
-if [ ! -f ${GREP} ]
+### Check to make sure a grep and find utility is available
+if [ ! -f ${GREP} ] || [ ! -f ${FIND} ]
 then
-    echo "ERROR: The grep binary does not exist in ${GREP} ."
-    echo "FIX: Please modify the \${GREP} variable in the program header."
+    echo "ERROR: Unable to locate the greb and find binary."
+    echo "FIX: Please modify the \${GREP} and \${FIND} variables in the program header."
     exit 1
 fi
 
@@ -783,6 +787,14 @@ elif [ "${CERTFILE}" != "" ]
 then
     print_heading
     check_file_status ${CERTFILE} "FILE"  "${CERTFILE}"
+
+### Check to see if the certificates in CERTDIRECTORY are about to expire
+elif [ "${CERTDIRECTORY}" != "" ] && (${FIND} -L ${CERTDIRECTORY} -type f > /dev/null 2>&1)
+then
+    print_heading
+    for FILE in `${FIND} -L ${CERTDIRECTORY} -type f`; do
+        check_file_status ${FILE} "FILE" "${FILE}"
+    done
 
 ### There was an error, so print a detailed usage message and exit
 else

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -16,6 +16,7 @@
 #  - Use highest returncode for Nagios output -- Marcel Pennewiss
 #  - Set RETCODE to 3 (unknown) if a certificate file does not exist -- Marcel Pennewiss
 #  - Add a "-d" option to specify a directory or file mask pattern -- Marcel Pennewiss
+#  - Add a "-N" option to create summarized Nagios output -- Marcel Pennewiss
 #
 # Version 3.29
 #  - Add the openssl -servername flag if it shows up in help.
@@ -231,6 +232,9 @@ ALARM="FALSE"
 # Don't run as a Nagios plugin by default (cmdline: -n)
 NAGIOS="FALSE"
 
+# Don't summarize Nagios output by default (cmdline: -N)
+NAGIOSSUMMARY="FALSE"
+
 # NULL out the PKCSDBPASSWD variable for later use (cmdline: -k)
 PKCSDBPASSWD=""
 
@@ -275,6 +279,15 @@ fi
 
 # Return code used by nagios. Initialize to 0.
 RETCODE=0
+
+# Certificate counters and minimum difference. Initialize to 0.
+SUMMARY_VALID=0
+SUMMARY_WILL_EXPIRE=0
+SUMMARY_EXPIRED=0
+SUMMARY_MIN_DIFF=0
+SUMMARY_MIN_DATE=
+SUMMARY_MIN_HOST=
+SUMMARY_MIN_PORT=
 
 # Set the default umask to be somewhat restrictive
 umask 077
@@ -362,7 +375,12 @@ date_diff()
 #####################################################################
 prints() 
 {
-    if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]
+    if [ "${NAGIOSSUMMARY}" == "TRUE" ]
+    then
+        return
+    fi
+
+    if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${VALIDATION}" != "TRUE" ] 
     then
         MIN_DATE=$(echo $4 | ${AWK} '{ print $1, $2, $4 }')
         if [ "${NAGIOS}" == "TRUE" ]
@@ -423,6 +441,33 @@ print_heading()
     fi
 }
 
+####################################################
+# Purpose: Print a summary for nagios
+# Arguments:
+#   None
+####################################################
+print_summary() 
+{
+    if [ "${NAGIOSSUMMARY}" != "TRUE" ]
+    then
+        return
+    fi
+
+    if [ ${SUMMARY_WILL_EXPIRE} -eq 0 ] && [ ${SUMMARY_EXPIRED} -eq 0 ]
+    then
+        ${PRINTF} "%s valid certificate(s)|days=%s\n" "${SUMMARY_VALID}" "${SUMMARY_MIN_DIFF}"
+
+    elif [ ${SUMMARY_EXPIRED} -ne 0 ]
+    then
+        ${PRINTF} "%s certificate(s) expired (%s:%s on %s)|days=%s\n" "${SUMMARY_EXPIRED}" "${SUMMARY_MIN_HOST}" "${SUMMARY_MIN_PORT}" "${SUMMARY_MIN_DATE}" "${SUMMARY_MIN_DIFF}"
+      
+    elif [ ${SUMMARY_WILL_EXPIRE} -ne 0 ]
+    then
+        ${PRINTF} "%s certificate(s) will expire (%s:%s on %s)|days=%s\n" "${SUMMARY_WILL_EXPIRE}" "${SUMMARY_MIN_HOST}" "${SUMMARY_MIN_PORT}" "${SUMMARY_MIN_DATE}" "${SUMMARY_MIN_DIFF}"
+
+    fi
+}
+
 #############################################################
 # Purpose: Set returncode to value if current value is lower
 # Arguments:
@@ -436,6 +481,38 @@ set_returncode()
     fi
 }
 
+########################################################################
+# Purpose: Set certificate counters and informations for nagios summary
+# Arguments:
+#   $1 -> Status of certificate (0: valid, 1: will expire, 2: expired)
+#   $2 -> Hostname
+#   $3 -> TCP Port 
+#   $4 -> Date when certificate will expire
+#   $5 -> Days left until the certificate will expire 
+########################################################################
+set_summary()
+{
+    if [ ${1} -eq 0 ]
+    then
+        SUMMARY_VALID=$((SUMMARY_VALID+1))
+
+    elif [ ${1} -eq 1 ]
+    then
+        SUMMARY_WILL_EXPIRE=$((SUMMARY_WILL_EXPIRE+1))
+
+    else
+        SUMMARY_EXPIRED=$((SUMMARY_EXPIRED+1))
+    fi
+
+    if [ ${5} -lt ${SUMMARY_MIN_DIFF} ] || [ ${SUMMARY_MIN_DIFF} -eq 0 ]
+    then
+        SUMMARY_MIN_DATE=${4}
+        SUMMARY_MIN_DIFF=${5}
+        SUMMARY_MIN_HOST=${2}
+        SUMMARY_MIN_PORT=${3}
+    fi
+}
+
 ##########################################
 # Purpose: Describe how the script works
 # Arguments:
@@ -443,8 +520,8 @@ set_returncode()
 ##########################################
 usage() 
 {
-    echo "Usage: $0 [ -e email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-v]"
-    echo "       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }"
+    echo "Usage: $0 [ -e email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v]"
+    echo "       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }" 
     echo ""
     echo "  -a                : Send a warning message through E-mail"
     echo "  -b                : Will not print header"
@@ -456,6 +533,7 @@ usage()
     echo "  -i                : Print the issuer of the certificate"
     echo "  -k password       : PKCS12 file password"
     echo "  -n                : Run as a Nagios plugin"
+    echo "  -N                : Run as a Nagios plugin and output one line summary (implies -n, requires -f or -d)"
     echo "  -p port           : Port to connect to (interactive mode)"
     echo "  -s commmon name   : Server to connect to (interactive mode)"
     echo "  -t type           : Specify the certificate type"
@@ -646,12 +724,14 @@ check_file_status() {
     fi
     
     set_returncode ${RETCODE_LOCAL}
+    MIN_DATE=$(echo ${CERTDATE} | ${AWK} '{ print $1, $2, $4 }')
+    set_summary ${RETCODE_LOCAL} ${HOST} ${PORT} "${MIN_DATE}" ${CERTDIFF}
 }
 
 #################################
 ### Start of main program
 #################################
-while getopts abinv:e:f:c:d:hk:p:s:t:qx:V option
+while getopts abinNv:e:f:c:d:hk:p:s:t:qx:V option
 do
     case "${option}"
     in
@@ -666,6 +746,8 @@ do
         i) ISSUER="TRUE";;
         k) PKCSDBPASSWD=${OPTARG};;
         n) NAGIOS="TRUE";;
+        N) NAGIOS="TRUE"
+           NAGIOSSUMMARY="TRUE";;
         p) PORT=$OPTARG;;
         s) HOST=$OPTARG;;
         t) CERTTYPE=$OPTARG;;
@@ -759,6 +841,7 @@ if [ "${HOST}" != "" ] && [ "${PORT}" != "" ]
 then
     print_heading
     check_server_status "${HOST}" "${PORT}"
+    print_summary
 
 ### If a file is passed to the "-f" option on the command line, check 
 ### each certificate or server / port combination in the file to see if 
@@ -781,12 +864,14 @@ then
         fi
     done
     IFS=${OLDIFS}
+    print_summary
 
 ### Check to see if the certificate in CERTFILE is about to expire
 elif [ "${CERTFILE}" != "" ]
 then
     print_heading
     check_file_status ${CERTFILE} "FILE"  "${CERTFILE}"
+    print_summary
 
 ### Check to see if the certificates in CERTDIRECTORY are about to expire
 elif [ "${CERTDIRECTORY}" != "" ] && (${FIND} -L ${CERTDIRECTORY} -type f > /dev/null 2>&1)
@@ -795,6 +880,7 @@ then
     for FILE in `${FIND} -L ${CERTDIRECTORY} -type f`; do
         check_file_status ${FILE} "FILE" "${FILE}"
     done
+    print_summary
 
 ### There was an error, so print a detailed usage message and exit
 else

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -8,9 +8,13 @@
 #
 # Author: Matty < matty91 at gmail dot com >
 #
-# Current Version: 3.29
+# Current Version: 3.30
 #
 # Revision History:
+#
+# Version 3.30
+#  - Use highest returncode for Nagios output -- Marcel Pennewiss
+#  - Set RETCODE to 3 (unknown) if a certificate file does not exist -- Marcel Pennewiss
 #
 # Version 3.29
 #  - Add the openssl -servername flag if it shows up in help.
@@ -198,6 +202,7 @@
 #  -- FreeBSD using /bin/sh
 #  -- Centos Linux 3, 4, 5 & 6 using /bin/bash
 #  -- Redhat Enterprise Linux 3, 4, 5 & 6 using /bin/bash
+#  -- Gentoo using /bin/bash
 # 
 # Usage:
 #  Refer to the usage() sub-routine, or invoke ssl-cert-check 
@@ -416,6 +421,18 @@ print_heading()
     fi
 }
 
+#############################################################
+# Purpose: Set returncode to value if current value is lower
+# Arguments:
+#   $1 -> New returncorde
+#############################################################
+set_returncode()
+{
+    if [ ${RETCODE} -lt ${1} ]
+    then
+        RETCODE=${1}
+    fi
+}
 
 ##########################################
 # Purpose: Describe how the script works
@@ -494,32 +511,32 @@ check_server_status() {
     if ${GREP} -i  "Connection refused" ${ERROR_TMP} > /dev/null
     then
         prints ${1} ${2} "Connection refused" "Unknown"  
-        RETCODE=3
+        set_returncode 3
 
     elif ${GREP} -i "No route to host" ${ERROR_TMP} > /dev/null
     then
         prints ${1} ${2} "No route to host" "Unknown"  
-        RETCODE=3
+        set_returncode 3
 
     elif ${GREP} -i "gethostbyname failure" ${ERROR_TMP} > /dev/null
     then
         prints ${1} ${2} "Cannot resolve domain" "Unknown" 
-        RETCODE=3
+        set_returncode 3
     
     elif ${GREP} -i "Operation timed out" ${ERROR_TMP} > /dev/null
     then
         prints ${1} ${2} "Operation timed out" "Unknown"  
-        RETCODE=3
+        set_returncode 3
  
     elif ${GREP} -i "ssl handshake failure" ${ERROR_TMP} > /dev/null
     then
         prints ${1} ${2} "SSL handshake failed" "Unknown"  
-        RETCODE=3
+        set_returncode 3
 
     elif ${GREP} -i "connect: Connection timed out" ${ERROR_TMP} > /dev/null
     then
         prints ${1} ${2} "Connection timed out" "Unknown"  
-        RETCODE=3
+        set_returncode 3
     
     else
         check_file_status ${CERT_TMP} $1 $2
@@ -544,7 +561,7 @@ check_file_status() {
     then
         echo "ERROR: The file named ${CERTFILE} is unreadable or doesn't exist"
         echo "ERROR: Please check to make sure the certificate for ${HOST}:${PORT} is valid"
-        RETCODE=1
+        set_returncode 3
         return
     fi
 
@@ -608,7 +625,7 @@ check_file_status() {
         fi
 
         prints ${HOST} ${PORT} "Expired" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
-        RETCODE=2
+        RETCODE_LOCAL=2
 
     elif [ ${CERTDIFF} -lt ${WARNDAYS} ]
     then
@@ -618,12 +635,14 @@ check_file_status() {
                  | ${MAIL} -s "Certificate for ${HOST} \"(CN: ${COMMONNAME})\" will expire in ${WARNDAYS}-days or less" ${ADMIN}
         fi
         prints ${HOST} ${PORT} "Expiring" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}" 
-        RETCODE=1
+        RETCODE_LOCAL=1
 
     else
         prints ${HOST} ${PORT} "Valid" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
-        RETCODE=0
+        RETCODE_LOCAL=0
     fi
+    
+    set_returncode ${RETCODE_LOCAL}
 }
 
 #################################
@@ -743,8 +762,13 @@ then
 elif [ -f "${SERVERFILE}" ]
 then
     print_heading
-    egrep -v '(^#|^$)' ${SERVERFILE} |  while read HOST PORT
+    
+    IFS=$'\n'
+    for LINE in `egrep -v '(^#|^$)' ${SERVERFILE}`
     do
+        HOST=${LINE%% *}
+        PORT=${LINE#* }
+        IFS=" "
         if [ "$PORT" = "FILE" ]
         then
             check_file_status ${HOST} "FILE" "${HOST}"
@@ -752,6 +776,7 @@ then
             check_server_status "${HOST}" "${PORT}"
         fi
     done
+    IFS=${OLDIFS}
 
 ### Check to see if the certificate in CERTFILE is about to expire
 elif [ "${CERTFILE}" != "" ]


### PR DESCRIPTION
This patchset will add some functionality and fix some issues concerning nagios output.
- Fix returncode handling for nagios output (for now only the latest returncode will be used if file list is in use)
- Fix returncode on file not found to UNKNOWN instead of WARNING - this is more common
- Add option to use directory or file pattern which allows to check folders more dynamic without creating a file list
- Add option to summarize output to a single line for nagios. Multiple lines will break NRPE compatibility which is often used with nagios.
