### PR TITLE
Corrected sendmail syntax

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -330,7 +330,7 @@ send_mail() {
             echo "$MSG" | ${MAIL} -r $FROM -s "$SUBJECT" $TO
             ;;
         "sendmail")
-            echo "Subject:$SUBJECT"$'\n'"$MSG" | ${MAIL} -t $TO -- -f $FROM
+            (echo "Subject:$SUBJECT" && echo "TO:$TO" && echo "FROM:$FROM" && echo "$MSG") | ${MAIL} $TO
             ;;
         "*")
             echo "ERROR: You enabled automated alerts, but the mail binary could not be found."


### PR DESCRIPTION
Hi,

The sendmail syntax contains an error. It would send the mail to `$TO` but also to `--@hostname`, `-f@hostname` and `$FROM`. I corrected this, and also added the TO address in the mail header. 