### PR TITLE
Hanlde bsd-mailx that don't have "-r" option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+domains.txt

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -265,7 +265,11 @@ MKTEMP=$(which mktemp)
 FIND=$(which find)
 
 # Try to find a mail client
-if [ -f /usr/bin/mailx ]
+if [ -f /usr/bin/bsd-mailx ]
+then
+    MAIL="/usr/bin/bsd-mailx"
+    MAILMODE="bsd-mailx"
+elif [ -f /usr/bin/mailx ]
 then
     MAIL="/usr/bin/mailx"
     MAILMODE="mailx"
@@ -326,6 +330,9 @@ send_mail() {
     MSG=${4}
 
     case "${MAILMODE}" in
+	"bsd-mailx")
+	    echo "$MSG" | ${MAIL} -s "$SUBJECT" $TO
+            ;; 
         "mail" | "mailx")
             echo "$MSG" | ${MAIL} -r $FROM -s "$SUBJECT" $TO
             ;;


### PR DESCRIPTION
Here is a list of few that do not have "-r" options:

bsd-mailx   8.1.2-0.20160123cvs-3  amd64
bsd-mailx   8.1.2-0.20141216cvs-2  amd64
bsd-mailx   8.1.2-0.20141216cvs-2  armhf
