### PR TITLE
Change path to bash

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Program: SSL Certificate Check <ssl-cert-check>
 #


### PR DESCRIPTION
Use /usr/bin/env to retrieve bash path instead of hard-coded path.