### PR TITLE
Get rid of HTTP Error 400 when HttpProtocolOptions set to "Strict"

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -636,7 +636,7 @@ check_server_status() {
          TLSFLAG="${TLSFLAG} -servername $1"
     fi
 
-    echo "" | ${OPENSSL} s_client ${VER} -connect ${1}:${2} ${TLSFLAG} 2> ${ERROR_TMP} 1> ${CERT_TMP}
+    echo "" | ${OPENSSL} s_client -crlf ${VER} -connect ${1}:${2} ${TLSFLAG} 2> ${ERROR_TMP} 1> ${CERT_TMP}
 
     if ${GREP} -i "Connection refused" ${ERROR_TMP} > /dev/null
     then


### PR DESCRIPTION
"OpenSSL s_client needs the -crlf parameter to work properly"
http://httpd.apache.org/docs/current/en/mod/core.html#httpprotocoloptions

I've tested this change successfully to solve "Bad Request" issue after upgrading to Apache webserver httpd-2.4.6-45.el7.centos.4.x86_64