### PR TITLE
Add support for connecting to XMPP servers.

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -12,6 +12,9 @@
 #
 # Revision History:
 #
+# Version 3.31
+#   - Add support for connecting to XMPP servers -- Simon Dellenbach
+#
 # Version 3.30
 #  - Use highest returncode for Nagios output -- Marcel Pennewiss
 #  - Set RETCODE to 3 (unknown) if a certificate file does not exist -- Marcel Pennewiss
@@ -622,6 +625,10 @@ check_server_status() {
     elif [ "_${2}" = "_submission" -o "_${2}" = "_587" ]
     then
         TLSFLAG="-starttls smtp -port ${2}"
+
+    elif [ "_${2}" = "_xmpp" -o "_${2}" = "_5222" ]
+    then
+        TLSFLAG="-starttls xmpp"
     else
         TLSFLAG=""
     fi


### PR DESCRIPTION
XMPP Servers such as _Openfire_ are using their own certificate store so it makes sense to validate it initiating an actual XMPP connection. For this, the `-starttls xmpp` parameter is required.

I've been using it on Centos 7.3 for over a year now (with v3.29).

#### Before
```
Host                                Issuer            Status   Expires     Days
----------------------------------- ----------------- -------- ----------- ----
unable to load certificate
140429712500640:error:0906D06C:PEM routines:PEM_read_bio:no start line:pem_lib.c:703:Expecting: TRUSTED CERTIFICATE
xmpp.example.com:5222                                 Expired              -2457996                               
```
#### After
```
Host                                Issuer            Status   Expires     Days
----------------------------------- ----------------- -------- ----------- ----
xmpp.example.com:5222               Let's Encrypt     Valid    Oct 21 2017 52                                 

```