### PR TITLE
Fixed parsing errors when filenames have spaces in them

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -288,7 +288,7 @@ then
 elif [ -f /usr/sbin/sendmail ]
 then
     MAIL="/usr/sbin/sendmail"
-    MAILMODE="sendmail"    
+    MAILMODE="sendmail"
 else
     MAIL="cantfindit"
     MAILMODE="cantfindit"
@@ -687,7 +687,7 @@ check_file_status() {
     PORT=${3}
 
     ### Check to make sure the certificate file exists
-    if [ ! -r ${CERTFILE} ] || [ ! -s ${CERTFILE} ]
+    if [ ! -r "${CERTFILE}" ] || [ ! -s "${CERTFILE}" ]
     then
         echo "ERROR: The file named ${CERTFILE} is unreadable or doesn't exist"
         echo "ERROR: Please check to make sure the certificate for ${HOST}:${PORT} is valid"
@@ -700,7 +700,7 @@ check_file_status() {
     then
         # Extract the certificate from the PKCS#12 database, and
         # send the informational message to /dev/null
-        ${OPENSSL} pkcs12 -nokeys -in ${CERTFILE} \
+        ${OPENSSL} pkcs12 -nokeys -in "${CERTFILE}" \
                    -out ${CERT_TMP} -clcerts -password pass:${PKCSDBPASSWD} 2> /dev/null
 
         # Extract the expiration date from the certificate
@@ -722,20 +722,20 @@ check_file_status() {
                    ${SED} -e 's/serial=//')
     else
         # Extract the expiration date from the ceriticate
-        CERTDATE=$(${OPENSSL} x509 -in ${CERTFILE} -enddate -noout -inform ${CERTTYPE} | \
+        CERTDATE=$(${OPENSSL} x509 -in "${CERTFILE}" -enddate -noout -inform ${CERTTYPE} | \
                  ${SED} 's/notAfter\=//')
 
         # Extract the issuer from the certificate
-        CERTISSUER=$(${OPENSSL} x509 -in ${CERTFILE} -issuer -noout -inform ${CERTTYPE} | \
+        CERTISSUER=$(${OPENSSL} x509 -in "${CERTFILE}" -issuer -noout -inform ${CERTTYPE} | \
                    ${AWK} 'BEGIN {RS="/" } $0 ~ /^O=/ { print substr($0,3,17)}')
 
         ### Grab the common name (CN) from the X.509 certificate
-        COMMONNAME=$(${OPENSSL} x509 -in ${CERTFILE} -subject -noout -inform ${CERTTYPE} | \
+        COMMONNAME=$(${OPENSSL} x509 -in "${CERTFILE}" -subject -noout -inform ${CERTTYPE} | \
                    ${SED} -e 's/.*CN=//' | \
                    ${SED} -e 's/\/.*//')
 
         ### Grab the serial number from the X.509 certificate
-        SERIAL=$(${OPENSSL} x509 -in ${CERTFILE} -serial -noout -inform ${CERTTYPE} | \
+        SERIAL=$(${OPENSSL} x509 -in "${CERTFILE}" -serial -noout -inform ${CERTTYPE} | \
                    ${SED} -e 's/serial=//')
     fi
 
@@ -755,7 +755,7 @@ check_file_status() {
                 "The SSL certificate for ${HOST} \"(CN: ${COMMONNAME})\" has expired!"
         fi
 
-        prints ${HOST} ${PORT} "Expired" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
+        prints ${HOST} "${PORT}" "Expired" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
         RETCODE_LOCAL=2
 
     elif [ ${CERTDIFF} -lt ${WARNDAYS} ]
@@ -765,17 +765,17 @@ check_file_status() {
             send_mail ${SENDER} ${ADMIN} "Certificate for ${HOST} \"(CN: ${COMMONNAME})\" will expire in ${WARNDAYS}-days or less" \
                 "The SSL certificate for ${HOST} \"(CN: ${COMMONNAME})\" will expire on ${CERTDATE}"
         fi
-        prints ${HOST} ${PORT} "Expiring" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
+        prints ${HOST} "${PORT}" "Expiring" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
         RETCODE_LOCAL=1
 
     else
-        prints ${HOST} ${PORT} "Valid" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
+        prints ${HOST} "${PORT}" "Valid" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
         RETCODE_LOCAL=0
     fi
 
     set_returncode ${RETCODE_LOCAL}
     MIN_DATE=$(echo ${CERTDATE} | ${AWK} '{ print $1, $2, $4 }')
-    set_summary ${RETCODE_LOCAL} ${HOST} ${PORT} "${MIN_DATE}" ${CERTDIFF}
+    set_summary ${RETCODE_LOCAL} ${HOST} "${PORT}" "${MIN_DATE}" ${CERTDIFF}
 }
 
 #################################
@@ -921,7 +921,7 @@ then
 elif [ "${CERTFILE}" != "" ]
 then
     print_heading
-    check_file_status ${CERTFILE} "FILE" "${CERTFILE}"
+    check_file_status "${CERTFILE}" "FILE" "${CERTFILE}"
     print_summary
 
 ### Check to see if the certificates in CERTDIRECTORY are about to expire

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -708,8 +708,8 @@ check_file_status() {
                  ${SED} 's/notAfter\=//')
 
         # Extract the issuer from the certificate
-        CERTISSUER=$(${OPENSSL} x509 -in ${CERT_TMP} -issuer -noout | \
-                   ${AWK} 'BEGIN {RS="/" } $0 ~ /^O=/ \
+        CERTISSUER=$(${OPENSSL} x509 -in ${CERT_TMP} -issuer -noout -nameopt sep_semi_plus_space | \
+                   ${AWK} 'BEGIN {RS="; " } $0 ~ /^O=/ \
                                  { print substr($0,3,17)}')
 
         ### Grab the common name (CN) from the X.509 certificate
@@ -726,8 +726,9 @@ check_file_status() {
                  ${SED} 's/notAfter\=//')
 
         # Extract the issuer from the certificate
-        CERTISSUER=$(${OPENSSL} x509 -in "${CERTFILE}" -issuer -noout -inform ${CERTTYPE} | \
-                   ${AWK} 'BEGIN {RS="/" } $0 ~ /^O=/ { print substr($0,3,17)}')
+        CERTISSUER=$(${OPENSSL} x509 -in "${CERTFILE}" -issuer -noout -inform ${CERTTYPE} \
+                    -nameopt sep_semi_plus_space | \
+                   ${AWK} 'BEGIN {RS="; " } $0 ~ /^O=/ { print substr($0,3,17)}')
 
         ### Grab the common name (CN) from the X.509 certificate
         COMMONNAME=$(${OPENSSL} x509 -in "${CERTFILE}" -subject -noout -inform ${CERTTYPE} | \

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -928,8 +928,8 @@ then
 elif [ "${CERTDIRECTORY}" != "" ] && (${FIND} -L ${CERTDIRECTORY} -type f > /dev/null 2>&1)
 then
     print_heading
-    for FILE in `${FIND} -L ${CERTDIRECTORY} -type f`; do
-        check_file_status ${FILE} "FILE" "${FILE}"
+    $FIND -L ${CERTDIRECTORY} -type f -print0 | while read -d $'\0' FILE; do
+        check_file_status "${FILE}" "FILE" "`basename \"${FILE}\"`"
     done
     print_summary
 


### PR DESCRIPTION
The following patches address three issues

- Ensure that filenames with spaces in them are handled correctly, especially when being passed to the $OPENSSL as parameters
- In the "for file in `find . -name`" construct, if find returns a filename with a space in it, then $file in the for loop breaks. Fixed this.
- OpenSSL v1.1.0f uses a "comma and space" (sep_comma_plus_space) by default when printing all the DN/CN fields. If the CN has commas in the O or OU field, then AWK parsing breaks. Fixed this by switching to sep_semi_plus_space for the "openssl x509" output.