### PR TITLE
Update extraction of certificate issuer

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -726,7 +726,7 @@ check_file_status() {
                  ${SED} 's/notAfter\=//')
 
         # Extract the issuer from the certificate
-        CERTISSUER=$(${OPENSSL} x509 -in ${CERTFILE} -issuer -noout -inform ${CERTTYPE} | \
+        CERTISSUER=$(${GREP} '^issuer=' ${CERTFILE} | \
                    ${AWK} 'BEGIN {RS="/" } $0 ~ /^O=/ { print substr($0,3,17)}')
 
         ### Grab the common name (CN) from the X.509 certificate


### PR DESCRIPTION
The issuer can be extracted from the temporary certificate file.

When using ssl-cert-check in Debian Stretch, the issuer will not be extracted, because the regular expression does not fit anymore when using openssl command. The format of the temporary certificate file is the same as in previous Debian releases, therefore the regular expression to extract the issuer still fits and grep does the job.

This is not tested against other Linux distributions.