### PR TITLE
use openssl -help instead of -h to check if -servername is supported

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -860,7 +860,7 @@ then
 fi
 
 # Send along the servername when TLS is used
-if ${OPENSSL} s_client -h 2>&1 | grep '-servername' > /dev/null
+if ${OPENSSL} s_client -help 2>&1 | grep '-servername' > /dev/null
 then
     TLSSERVERNAME="TRUE"
 else


### PR DESCRIPTION
Newer versions of openssl ( tested with OpenSSL 1.1.0f  25 May 2017 ) do not support -h anymore. Instead use -help option which is also supported in older versions ( tested with OpenSSL 0.9.8o 01 Jun 2010 ).