### PR TITLE
autodetect the real CERTTYPE based on file extension

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -248,8 +248,8 @@ NAGIOSSUMMARY="FALSE"
 # NULL out the PKCSDBPASSWD variable for later use (cmdline: -k)
 PKCSDBPASSWD=""
 
-# Type of certificate (PEM, DER, NET) (cmdline: -t)
-CERTTYPE="pem"
+# Type of certificate (auto, PEM, DER, NET) (cmdline: -t)
+CERTTYPE_USER="auto"
 
 # Protocol version to use (cmdline: -v)
 VERSION=""
@@ -724,6 +724,20 @@ check_file_status() {
         SERIAL=$(${OPENSSL} x509 -in ${CERT_TMP} -serial -noout | \
                    ${SED} -e 's/serial=//')
     else
+        # figure out the CERTTYPE.  If explicitly provided by user,
+        # use that.  If the special value "auto", then autodetect.
+        if [ "${CERTTYPE_USER}" = "auto" ]; then
+          CERTTYPE=PEM; # default
+          for CERTTYPE_TRY in DER NET PEM; do
+            if ${OPENSSL} x509 -in ${CERTFILE} -enddate -noout -inform ${CERTTYPE_TRY} >/dev/null 2>&1; then
+              CERTTYPE=${CERTTYPE_TRY}
+              break
+            fi
+          done
+        else
+          CERTTYPE="${CERTTYPE_USER}"
+        fi
+
         # Extract the expiration date from the ceriticate
         CERTDATE=$(${OPENSSL} x509 -in ${CERTFILE} -enddate -noout -inform ${CERTTYPE} | \
                  ${SED} 's/notAfter\=//')
@@ -804,7 +818,7 @@ do
            NAGIOSSUMMARY="TRUE";;
         p) PORT=$OPTARG;;
         s) HOST=$OPTARG;;
-        t) CERTTYPE=$OPTARG;;
+        t) CERTTYPE_USER=$OPTARG;;
         q) QUIET="TRUE";;
         v) VERSION=$OPTARG;;
         V) VALIDATION="TRUE";;

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -251,6 +251,12 @@ PKCSDBPASSWD=""
 # Type of certificate (auto, PEM, DER, NET) (cmdline: -t)
 CERTTYPE_USER="auto"
 
+# the list of certificate types to autodetect when CERTTYPE_USER is auto
+CERTTYPES_TO_AUTODETECT="PEM DER NET"
+
+# the default certtype if autodetection can't figure it out
+CERTTYPE_DEFAULT="PEM"
+
 # Protocol version to use (cmdline: -v)
 VERSION=""
 
@@ -727,8 +733,8 @@ check_file_status() {
         # figure out the CERTTYPE.  If explicitly provided by user,
         # use that.  If the special value "auto", then autodetect.
         if [ "${CERTTYPE_USER}" = "auto" ]; then
-          CERTTYPE=PEM; # default
-          for CERTTYPE_TRY in DER NET PEM; do
+          CERTTYPE=${CERTTYPE_DEFAULT}
+          for CERTTYPE_TRY in ${CERTTYPES_TO_AUTODETECT}; do
             if ${OPENSSL} x509 -in ${CERTFILE} -enddate -noout -inform ${CERTTYPE_TRY} >/dev/null 2>&1; then
               CERTTYPE=${CERTTYPE_TRY}
               break


### PR DESCRIPTION
I have a directory with a mix of openssl files.  It has certs in pem format, certs in der format, private keys, a pkcs12 file.  I'd like to monitor this without messing with the current (lack of) organization.  One step: autodetect the format of the cert files based on file extension.

The idea is to allow -t to take a new value, "auto".  If set to "auto", then autodetect the cert format, defaulting to pem.  If set to something else, use that other value.

The simpler way to do this, code-wise, is to just look at file extension.  But that's not very Unix-y.  A more Unix-y way to do it would be to try openssl with the different possibilities until one works.  I've gone with the file extension approach in this commit.  If you prefer the other approach, please let me know.
