### PR TITLE
Fix TLSFLAG bug issue #50

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -658,9 +658,9 @@ check_server_status() {
     fi
 
     if [ "${TLSSERVERNAME}" = "FALSE" ]; then
-	TLSFLAG=(s_client -crlf -connect "${1}":"${2}")
+        TLSFLAG=(s_client -crlf -connect "${1}":"${2}" $TLSFLAG)
     else
-        TLSFLAG=(s_client -crlf -connect "${1}":"${2}" -servername "${1}")
+        TLSFLAG=(s_client -crlf -connect "${1}":"${2}" -servername "${1}" $TLSFLAG)
     fi
 
     echo "" | "${OPENSSL}" "${TLSFLAG[@]}" 2> "${ERROR_TMP}" 1> "${CERT_TMP}"


### PR DESCRIPTION
Per comment in issue #50, fix overridden TLSFLAG that breaks, e.g., host:587 check.