### PR TITLE
Unset variables before evaluating options (avoid conflicts with environment variables)

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -804,6 +804,15 @@ check_file_status() {
 #################################
 ### Start of main program
 #################################
+
+### Unset variables that are used in options-evaluation and subsequent control flow (and could be defined in the environment already)
+unset ALARM
+unset CERTFILE
+unset CERTDIRECTORY
+unset HOST
+unset NAGIOS
+unset SERVERFILE
+
 while getopts abc:d:e:E:f:hik:nNp:qs:St:Vx: option
 do
     case "${option}" in


### PR DESCRIPTION
Before the arguments to the script are evaluated all variables that are used in the subsequent control flow are unset (in order to avoid conflicts with corresponding variables defined in the environment already, see #78).