### PR TITLE
Trim CR-LF when parsing LINE from file

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -917,6 +917,7 @@ elif [ -f "${SERVERFILE}" ]; then
     IFS=$'\n'
     for LINE in $(grep -E -v '(^#|^$)' "${SERVERFILE}")
     do
+        LINE=${LINE/$'\r'/}
         HOST=${LINE%% *}
         PORT=${LINE##* }
         IFS=" "


### PR DESCRIPTION
### Current issue

Using a CR-LF encoded file and running `ssl-cert-check -f filename` currently results in invalid PORT parsing and later failing `openssl` command 

The currently visible error is 
```
ERROR: The file named /var/tmp/cert.XXXXX is unreadable or doesn't exist
```

but after some debuging I found out that `"${OPENSSL}" s_client $OPTIONS 2> "${ERROR_TMP}" 1> "${CERT_TMP}"` fails with
```
25769803792:error:2008F002:BIO routines:BIO_lookup_ex:system lib:crypto/bio/b_addr.c:724:Servname not supported for ai_socktype
connect:errno=88
```
This is due to `$OPTIONS` being truncated as the `$2` variable inside it has a CR-LF char, so the command passed to openssl has invalid syntax.

Here's what `$OPTIONS` look like with CR-LF input file : 
`"-servername host.domain.local"` 
the first half of the command is truncated (`"-connect ${1}:${2}"`)

### Fix 
We can make the script compatible with CR-LF input files by removing `\r` from the parsed line.

[some issues](https://github.com/Matty9191/ssl-cert-check/issues/77) mention this error, I guess they were running the command against CR-LF input file.

Should not be a breaking change, I tried with CR-LF and LF encoded file, both works with this fix.