### PR TITLE
Add support for mail delivery using `s-nail`

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -325,6 +325,9 @@ FIND=$(command -v find)
 if [ -f /usr/bin/mailx ]; then
     MAIL="/usr/bin/mailx"
     MAILMODE="mailx"
+elif [ -f /usr/bin/s-nail ]; then
+    MAIL="/usr/bin/s-nail"
+    MAILMODE="mailx"
 elif [ -f /bin/mail ]; then
     MAIL="/bin/mail"
     MAILMODE="mail"


### PR DESCRIPTION
`s-nail` is an alternative to `mailx` that provides the same interface. It is additionally the default on some platforms like Arch.