### PR TITLE
fix openssl timeout error message

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -13,6 +13,9 @@ PROGRAMVERSION=4.14
 #
 # Revision History:
 #
+# Version 4.15
+#  - Fixed openssl timeout error message @ryantm
+#
 # Version 4.14
 #  - Fixed HOST / PORT discovery @mhow2
 #
@@ -691,7 +694,7 @@ check_server_status() {
     elif "${GREP}" -i "ssl handshake failure" "${ERROR_TMP}" > /dev/null; then
         prints "${1}" "${2}" "SSL handshake failed" "Unknown"
         set_returncode 3
-    elif "${GREP}" -i "connect: Connection timed out" "${ERROR_TMP}" > /dev/null; then
+    elif "${GREP}" -i "connect:Connection timed out" "${ERROR_TMP}" > /dev/null; then
         prints "${1}" "${2}" "Connection timed out" "Unknown"
         set_returncode 3
     elif "${GREP}" -i "Name or service not known" "${ERROR_TMP}" > /dev/null; then


### PR DESCRIPTION
When I run this
```
$ openssl version
OpenSSL 1.1.1k  25 Mar 2021
$ openssl s_client -connect timeout.badssl.com:444
139666931979584:error:0200206E:system library:connect:Connection timed out:crypto/bio/b_sock2.c:110:
139666931979584:error:2008A067:BIO routines:BIO_connect:connect error:crypto/bio/b_sock2.c:111:
connect:errno=110
```
Note the error message does not contain a space. This removes the space so a proper error message can be displayed instead of 

```
ERROR: The file named /var/tmp/cert.gjtbl2 is unreadable or doesn't exist
ERROR: Please check to make sure the certificate for redacted.com:443 is valid
```