### PR TITLE
Fix HOST variable not initialized, but inherited from external scope

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -308,6 +308,9 @@ NAGIOSSUMMARY="FALSE"
 # NULL out the PKCSDBPASSWD variable for later use (cmdline: -k)
 PKCSDBPASSWD=""
 
+# NULL out the HOST variable for later use, otherwise a global variable will be used to specify the host
+HOST=""
+
 # Type of certificate (PEM, DER, NET) (cmdline: -t)
 CERTTYPE="pem"
 


### PR DESCRIPTION
If inherited from outer scope, an existing HOST variable will act as if a commandline parameter has been given, rendering -f option useless.