### PR TITLE
v5.0: ssl-cert-check updates for FCCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ ssl-cert-check is a Bourne shell script that can be used to report on expiring S
 # Usage:
 <pre>
 $ ./ssl-cert-check
-Usage: ./ssl-cert-check [ -e email address ] [ -E sender email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v]
+Usage: ./ssl-cert-check [ -e email address ] [ -E sender email address ] [ -x days ] [ -X secs ] [-q] [-a] [-b] [-C] [-h] [-i] [-n] [-N] [-v]
        { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }"
 
   -a                : Send a warning message through E-mail
   -b                : Will not print header
   -c cert file      : Print the expiration date for the PEM or PKCS12 formatted certificate in cert file
+  -C                : CSV output
   -d cert directory : Print the expiration date for the PEM or PKCS12 formatted certificates in cert directory
   -e E-mail address : E-mail address to send expiration notices
   -E E-mail address : Sender E-mail address
@@ -27,6 +28,7 @@ Usage: ./ssl-cert-check [ -e email address ] [ -E sender email address ] [ -x da
   -v                : Specify a specific protocol version to use (tls, ssl2, ssl3)
   -V                : Only print validation data
   -x days           : Certificate expiration interval (eg. if cert_date < days)
+  -X secs           : openssl timeout period in seconds
 </pre>
 
 # Examples:

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -1,242 +1,22 @@
 #!/usr/bin/env bash
-PROGRAMVERSION=4.14
+PROGRAMVERSION=5.0
 #
 # Program: SSL Certificate Check <ssl-cert-check>
 #
-# Source code home: https://github.com/Matty9191/ssl-cert-check
+# Source code home: https://github.com/Foundation-CCC/ssl-cert-check
 #
 # Documentation: http://prefetch.net/articles/checkcertificate.html
 #
+# Maintainer: Chris Chan < cchan at foundationccc dot org >
+#
 # Author: Matty < matty at prefetch dot net >
 #
-# Last Updated: 11-12-2020
+# Last Updated: 09-18-2023
 #
-# Revision History:
+# FCCC Revision History
 #
-# Version 4.14
-#  - Fixed HOST / PORT discovery @mhow2
-#
-# Version 4.13
-#  - Reverted the file checking logic which breaks $RETCODE
-#
-# Version 4.12
-#  - Fixed various logic errors and typos -- Daniel Lewart
-#
-# Version 4.10
-#  - Replace tabs with spaces
-#  - More shllcheck cleanup work
-#  - Remove unused DEBUG variable
-#  - Fixed an innocuous whitespace bug in TLSFLAG variable creation
-#  - Set the default TLS version to 1.1 (can be overridden with -v)
-#  - Switched openssl CLI options to use an array. The reasons why
-#    are documented here: http://mywiki.wooledge.org/BashFAQ/050
-#
-# Version 4.9
-#  - Add a signal handler to call the cleanup funtion
-#    if the script doesn't exit() cleanly -- Timothe Litt
-#
-# Version 4.8
-#  - More mail client fixes
-#
-# Version 4.7
-#  - Revert SENDER to ""
-#  - More shellcheck cleanup
-#
-# Version 4.6
-#  - Fixed programming logic error
-#
-# Version 4.5
-#  - Re-work mailx support for FreeBSD
-#  - More shellcheck fixes
-#
-# Version 4.4
-#  - Use command -v instead of which utility to satisfy shellcheck.
-#  - Fix unquoted MAIL and MAILMODE variables in help output
-#  - More shellcheck fixes
-#
-# Version 4.3
-#  - Fixed a typo in the program version
-#
-# Version 4.2
-#  - Change CERTDAYS to CERTDIFF in the e-mail subject.
-#
-# Version 4.1
-#  - Fix usage output
-#
-# Version 4.0
-#  - Updated the script syntax to align with UNIX shell programming
-#  - Check for DNS resolution failures
-#  - First round of updates to make shellcheck happy
-#  - Rework the logic to call mailx.
-#  - Print the version with the "-V" option.
-#  - Define the version in the PROGRAMVERSION variable
-#
-# Version 3.31
-#  - Fixed the test for the -servername flag -- Kitson Consulting.
-#
-# Version 3.30
-#  - Use highest returncode for Nagios output -- Marcel Pennewiss
-#  - Set RETCODE to 3 (unknown) if a certificate file does not exist -- Marcel Pennewiss
-#  - Add a "-d" option to specify a directory or file mask pattern -- Marcel Pennewiss
-#  - Add a "-N" option to create summarized Nagios output -- Marcel Pennewiss
-#  - Cleaned up many formatting -- Marcel Pennewiss
-#
-# Versione 3.29a
-#  - Added option to specify email sender address
-#
-# Version 3.29
-#  - Add the openssl -servername flag if it shows up in help.
-#
-# Version 3.28
-#  - Added a DEBUG option to assist with debugging folks who use the script
-#
-# Version 3.27
-#  - Allow white spaces to exist in the certificate file list
-#  - Add an additional check to pick up bad / non-existent certificates
-#  - Add a check to look for the existence of a mail program. Error out if it's not present.
-#  - Enable the TLS -servername extension by default - Juergen Knaack & Johan Denoyer
-#
-# Version 3.26
-#  - Allow the certificate type (PEM, DER, NET) to be passed on the command line
-#
-# Version 3.25
-#   - Check for "no route to host" errors -- Dan Doyle
-#   - Set RETCODE to 3 (unknown) if a connection error occurs -- Dan Doyle
-#   - Documentation fixes
-#
-# Version 3.24
-#   - Utilize the -clcerts option to limit the results to client certificates - Eitan Katznelson
-#
-# Version 3.23
-#   - Fixed typo in date2julian routine -- Ken Cook
-#
-# Version 3.22
-#   - Change the validation option to "-V"
-#   - Add a "-v" option to specify a specific protocol version (ssl2, ssl3 or tls)
-#
-# Version 3.21
-#   - Adjust e-mail checking to avoid exiting if notifications aren't enabled -- Nick Anderson
-#   - Added the number of days until expiration to the Nagios output -- Nick Anderson
-#
-# Version 3.20
-#   - Fixed a bug in certificate length checking -- Tim Nowaczyk
-#
-# Version 3.19
-#   - Added check to verify the certificate retrieved is valid
-#
-# Version 3.18
-#   - Add support for connecting to FTP servers -- Paul A Sand
-#
-# Version 3.17
-#   - Add support for connecting to imap servers -- Joerg Pareigis
-#
-# Version 3.16
-#   - Add support for connecting to the mail sbmission port -- Luis E. Munoz
-#
-# Version 3.15
-#   - Adjusted the file checking logic to use the correct certificate -- Maciej Szudejko
-#   - Add sbin to the default search paths for OpenBSD compatibility -- Alex Popov
-#   - Use cut instead of substring processing to ensure compatibility -- Alex Popov
-#
-# Version 3.14
-#   - Fixed the Common Name parser to handle DN's where the CN is not the last item
-#     eg. EmailAddr -- Jason Brothers
-#   - Added the ability to grab the serial number -- Jason Brothers
-#   - Added the "-b" option to print results without a header -- Jason Brothers
-#   - Added the "-v" option for certificate validation -- Jason Brothers
-#
-# Version 3.13
-#   - Updated the subject line to include the hostname as well as
-#     the common name embedded in the X509 certificate (if it's
-#     available) -- idea proposed by Mike Burns
-#
-#  Version 3.12
-#   - Updated the license to allow redistribution and modification
-#
-#  Version 3.11
-#   - Added ability to comment out lines in files passed
-#     to the "-f" option -- Brett Stauner
-#   - Fixed comment next to file processing logic
-#
-#  Version 3.10
-#   - Fixed POP3 port -- Simon Matter
-#
-#  Version 3.9
-#    - Switched binary location logic to use which utility
-#
-#  Version 3.8
-#    - Fixed display on 80 column displays
-#    - Cleaned up the formatting
-#
-#  Version 3.7
-#    - Fixed bug in NAGIOS tests -- Ben Allen
-#
-#  Version 3.6
-#    - Added support for certificates stored in PKCS#12 databases -- Ken Gallo
-#    - Cleaned up comments
-#    - Adjusted variables to be more consistent
-#
-#  Version 3.5
-#    - Added support for NAGIOS -- Quanah Gibson-Mount
-#    - Added additional checks for mail -- Quanah Gibson-Mount
-#    - Convert tabs to spaces -- Quanah Gibson-Mount
-#    - Cleaned up usage() routine
-#    - Added additional checks for openssl
-#
-#  Version 3.4
-#   - Added a missing "{" to line 364 -- Ken Gallo
-#   - Move mktemp to the start of the main body to avoid errors
-#   - Adjusted default binary paths to make sure the script just works
-#     w/ Solaris, BSD and Linux hosts
-#
-#  Version 3.3
-#   - Added common name from X.509 certificate file to E-mail body / header -- Doug Curtis
-#   - Fixed several documentation errors
-#   - Use mktemp to create temporary files
-#   - Convert printf, sed and awk to variables
-#   - Check for printf, sed, awk and mktemp binaries
-#   - Add additional logic to make sure mktemp returned a valid temporary file
-#
-#  Version 3.2
-#   - Added option to list certificates in the file passed to "-f".
-#
-#  Version 3.1
-#   - Added handling for starttls for smtp -- Marco Amrein
-#   - Added handling for starttls for pop3 (without s) -- Marco Amrein
-#   - Removed extra spacing at end of script
-#
-#  Version 3.0
-#   - Added "-i" option to print certificate issuer
-#   - Removed $0 from Subject line of outbound e-mails
-#   - Fixed some typographical errors
-#   - Removed redundant "-b" option
-#
-#  Version 2.0
-#    - Fixed an issue with e-mails formatting incorrectly
-#    - Added additional space to host column -- Darren-Perot Spruell
-#    - Replaced GNU date dependency with CHRIS F. A. JOHNSON's
-#      date2julian shell function. This routine can be found on
-#      page 170 of Chris's book "Shell Scripting Recipes: A
-#      Problem-Solution Approach," ISBN #1590594711. Julian function
-#      was created based on a post to comp.unix.shell by Tapani Tarvainen.
-#    - Cleaned up function descriptions
-#    - Removed several lines of redundant code
-#    - Adjusted the help message
-#
-#   Version 1.1
-#    - Added "-c" flag to report expiration status of a PEM encoded
-#      certificate -- Hampus Lundqvist
-#    - Updated the prints messages to display the reason a connection
-#      failed (connection refused, connection timeout, bad cert, etc)
-#    - Updated the GNU date checking routines
-#    - Added checks for each binary required
-#    - Added checks for connection timeouts
-#    - Added checks for GNU date
-#    - Added a "-h" option
-#    - Cleaned up the documentation
-#
-#  Version 1.0
-#      Initial Release
+# Version 5.0
+#  - Forked from https://github.com/Matty9191/ssl-cert-check
 #
 # Purpose:
 #  ssl-cert-check checks to see if a digital certificate in X.509 format
@@ -953,3 +733,231 @@ if [ "${NAGIOS}" = "TRUE" ]; then
 else
     exit 0
 fi
+
+# Additional Revision History:
+#
+# Version 4.14
+#  - Fixed HOST / PORT discovery @mhow2
+#
+# Version 4.13
+#  - Reverted the file checking logic which breaks $RETCODE
+#
+# Version 4.12
+#  - Fixed various logic errors and typos -- Daniel Lewart
+#
+# Version 4.10
+#  - Replace tabs with spaces
+#  - More shllcheck cleanup work
+#  - Remove unused DEBUG variable
+#  - Fixed an innocuous whitespace bug in TLSFLAG variable creation
+#  - Set the default TLS version to 1.1 (can be overridden with -v)
+#  - Switched openssl CLI options to use an array. The reasons why
+#    are documented here: http://mywiki.wooledge.org/BashFAQ/050
+#
+# Version 4.9
+#  - Add a signal handler to call the cleanup funtion
+#    if the script doesn't exit() cleanly -- Timothe Litt
+#
+# Version 4.8
+#  - More mail client fixes
+#
+# Version 4.7
+#  - Revert SENDER to ""
+#  - More shellcheck cleanup
+#
+# Version 4.6
+#  - Fixed programming logic error
+#
+# Version 4.5
+#  - Re-work mailx support for FreeBSD
+#  - More shellcheck fixes
+#
+# Version 4.4
+#  - Use command -v instead of which utility to satisfy shellcheck.
+#  - Fix unquoted MAIL and MAILMODE variables in help output
+#  - More shellcheck fixes
+#
+# Version 4.3
+#  - Fixed a typo in the program version
+#
+# Version 4.2
+#  - Change CERTDAYS to CERTDIFF in the e-mail subject.
+#
+# Version 4.1
+#  - Fix usage output
+#
+# Version 4.0
+#  - Updated the script syntax to align with UNIX shell programming
+#  - Check for DNS resolution failures
+#  - First round of updates to make shellcheck happy
+#  - Rework the logic to call mailx.
+#  - Print the version with the "-V" option.
+#  - Define the version in the PROGRAMVERSION variable
+#
+# Version 3.31
+#  - Fixed the test for the -servername flag -- Kitson Consulting.
+#
+# Version 3.30
+#  - Use highest returncode for Nagios output -- Marcel Pennewiss
+#  - Set RETCODE to 3 (unknown) if a certificate file does not exist -- Marcel Pennewiss
+#  - Add a "-d" option to specify a directory or file mask pattern -- Marcel Pennewiss
+#  - Add a "-N" option to create summarized Nagios output -- Marcel Pennewiss
+#  - Cleaned up many formatting -- Marcel Pennewiss
+#
+# Versione 3.29a
+#  - Added option to specify email sender address
+#
+# Version 3.29
+#  - Add the openssl -servername flag if it shows up in help.
+#
+# Version 3.28
+#  - Added a DEBUG option to assist with debugging folks who use the script
+#
+# Version 3.27
+#  - Allow white spaces to exist in the certificate file list
+#  - Add an additional check to pick up bad / non-existent certificates
+#  - Add a check to look for the existence of a mail program. Error out if it's not present.
+#  - Enable the TLS -servername extension by default - Juergen Knaack & Johan Denoyer
+#
+# Version 3.26
+#  - Allow the certificate type (PEM, DER, NET) to be passed on the command line
+#
+# Version 3.25
+#   - Check for "no route to host" errors -- Dan Doyle
+#   - Set RETCODE to 3 (unknown) if a connection error occurs -- Dan Doyle
+#   - Documentation fixes
+#
+# Version 3.24
+#   - Utilize the -clcerts option to limit the results to client certificates - Eitan Katznelson
+#
+# Version 3.23
+#   - Fixed typo in date2julian routine -- Ken Cook
+#
+# Version 3.22
+#   - Change the validation option to "-V"
+#   - Add a "-v" option to specify a specific protocol version (ssl2, ssl3 or tls)
+#
+# Version 3.21
+#   - Adjust e-mail checking to avoid exiting if notifications aren't enabled -- Nick Anderson
+#   - Added the number of days until expiration to the Nagios output -- Nick Anderson
+#
+# Version 3.20
+#   - Fixed a bug in certificate length checking -- Tim Nowaczyk
+#
+# Version 3.19
+#   - Added check to verify the certificate retrieved is valid
+#
+# Version 3.18
+#   - Add support for connecting to FTP servers -- Paul A Sand
+#
+# Version 3.17
+#   - Add support for connecting to imap servers -- Joerg Pareigis
+#
+# Version 3.16
+#   - Add support for connecting to the mail sbmission port -- Luis E. Munoz
+#
+# Version 3.15
+#   - Adjusted the file checking logic to use the correct certificate -- Maciej Szudejko
+#   - Add sbin to the default search paths for OpenBSD compatibility -- Alex Popov
+#   - Use cut instead of substring processing to ensure compatibility -- Alex Popov
+#
+# Version 3.14
+#   - Fixed the Common Name parser to handle DN's where the CN is not the last item
+#     eg. EmailAddr -- Jason Brothers
+#   - Added the ability to grab the serial number -- Jason Brothers
+#   - Added the "-b" option to print results without a header -- Jason Brothers
+#   - Added the "-v" option for certificate validation -- Jason Brothers
+#
+# Version 3.13
+#   - Updated the subject line to include the hostname as well as
+#     the common name embedded in the X509 certificate (if it's
+#     available) -- idea proposed by Mike Burns
+#
+#  Version 3.12
+#   - Updated the license to allow redistribution and modification
+#
+#  Version 3.11
+#   - Added ability to comment out lines in files passed
+#     to the "-f" option -- Brett Stauner
+#   - Fixed comment next to file processing logic
+#
+#  Version 3.10
+#   - Fixed POP3 port -- Simon Matter
+#
+#  Version 3.9
+#    - Switched binary location logic to use which utility
+#
+#  Version 3.8
+#    - Fixed display on 80 column displays
+#    - Cleaned up the formatting
+#
+#  Version 3.7
+#    - Fixed bug in NAGIOS tests -- Ben Allen
+#
+#  Version 3.6
+#    - Added support for certificates stored in PKCS#12 databases -- Ken Gallo
+#    - Cleaned up comments
+#    - Adjusted variables to be more consistent
+#
+#  Version 3.5
+#    - Added support for NAGIOS -- Quanah Gibson-Mount
+#    - Added additional checks for mail -- Quanah Gibson-Mount
+#    - Convert tabs to spaces -- Quanah Gibson-Mount
+#    - Cleaned up usage() routine
+#    - Added additional checks for openssl
+#
+#  Version 3.4
+#   - Added a missing "{" to line 364 -- Ken Gallo
+#   - Move mktemp to the start of the main body to avoid errors
+#   - Adjusted default binary paths to make sure the script just works
+#     w/ Solaris, BSD and Linux hosts
+#
+#  Version 3.3
+#   - Added common name from X.509 certificate file to E-mail body / header -- Doug Curtis
+#   - Fixed several documentation errors
+#   - Use mktemp to create temporary files
+#   - Convert printf, sed and awk to variables
+#   - Check for printf, sed, awk and mktemp binaries
+#   - Add additional logic to make sure mktemp returned a valid temporary file
+#
+#  Version 3.2
+#   - Added option to list certificates in the file passed to "-f".
+#
+#  Version 3.1
+#   - Added handling for starttls for smtp -- Marco Amrein
+#   - Added handling for starttls for pop3 (without s) -- Marco Amrein
+#   - Removed extra spacing at end of script
+#
+#  Version 3.0
+#   - Added "-i" option to print certificate issuer
+#   - Removed $0 from Subject line of outbound e-mails
+#   - Fixed some typographical errors
+#   - Removed redundant "-b" option
+#
+#  Version 2.0
+#    - Fixed an issue with e-mails formatting incorrectly
+#    - Added additional space to host column -- Darren-Perot Spruell
+#    - Replaced GNU date dependency with CHRIS F. A. JOHNSON's
+#      date2julian shell function. This routine can be found on
+#      page 170 of Chris's book "Shell Scripting Recipes: A
+#      Problem-Solution Approach," ISBN #1590594711. Julian function
+#      was created based on a post to comp.unix.shell by Tapani Tarvainen.
+#    - Cleaned up function descriptions
+#    - Removed several lines of redundant code
+#    - Adjusted the help message
+#
+#   Version 1.1
+#    - Added "-c" flag to report expiration status of a PEM encoded
+#      certificate -- Hampus Lundqvist
+#    - Updated the prints messages to display the reason a connection
+#      failed (connection refused, connection timeout, bad cert, etc)
+#    - Updated the GNU date checking routines
+#    - Added checks for each binary required
+#    - Added checks for connection timeouts
+#    - Added checks for GNU date
+#    - Added a "-h" option
+#    - Cleaned up the documentation
+#
+#  Version 1.0
+#      Initial Release
+#

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -16,6 +16,17 @@ PROGRAMVERSION=5.0
 # FCCC Revision History
 #
 # Version 5.0
+#  - Added configurable timeout for the openssl call (-X)
+#  - Added CSV output (-C)
+#  - If -i, -S and -C are present, output all the fields
+#  - Restore SIGINT ability to cancel script
+#  - fixed handling of input file. Expected format of file is "server[:port]"
+#    Default port is 443 (SSL).
+#  - print "Timed out" status to table instead of error message if openssl s_client failed.
+#  - get the Server Alternative Names data from the certificate (for wildcard certs)
+#  - fixed bug in getting the issuer of the certificate
+#
+# Version 5.0a
 #  - Forked from https://github.com/Matty9191/ssl-cert-check
 #
 # Purpose:
@@ -61,7 +72,7 @@ PROGRAMVERSION=5.0
 # Cleanup temp files if they exist
 trap cleanup EXIT INT TERM QUIT
 
-PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/ssl/bin:/usr/sfw/bin
+PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/ssl/bin:/usr/sfw/bin:/opt/homebrew/bin:.
 export PATH
 
 # Who to page when an expired certificate is detected (cmdline: -e)
@@ -100,6 +111,7 @@ PRINTF=$(command -v printf)
 SED=$(command -v sed)
 MKTEMP=$(command -v mktemp)
 FIND=$(command -v find)
+TIMEOUT=$(command -v timeout)
 
 # Try to find a mail client
 if [ -f /usr/bin/mailx ]; then
@@ -146,6 +158,7 @@ umask 077
 #          exit() cleanly
 #####################################################
 cleanup() {
+    trap - INT # restore default INT handler
     if [ -f "${CERT_TMP}" ]; then
         rm -f "${CERT_TMP}"
     fi
@@ -153,6 +166,7 @@ cleanup() {
     if [ -f "${ERROR_TMP}" ]; then
      rm -f "${ERROR_TMP}"
     fi
+    kill -s INT "$$"
 }
 
 
@@ -269,6 +283,7 @@ date_diff()
 #   $6 -> Issuer of the certificate
 #   $7 -> Common Name
 #   $8 -> Serial Number
+#   $9 -> Subject Alternative Name
 #####################################################################
 prints()
 {
@@ -280,21 +295,32 @@ prints()
         MIN_DATE=$(echo "$4" | "${AWK}" '{ printf "%3s %2d %4d", $1, $2, $4 }')
         if [ "${NAGIOS}" = "TRUE" ]; then
             ${PRINTF} "%-35s %-17s %-8s %-11s %s\n" "$1:$2" "$6" "$3" "$MIN_DATE" "|days=$5"
+        elif [ "${CSV}" = "TRUE" ]; then
+            ${PRINTF} '"%s","%s","%s","%s",%4d\n' "$1:$2" "$6" "$3" "$MIN_DATE" "$5"
         else
             ${PRINTF} "%-35s %-17s %-8s %-11s %4d\n" "$1:$2" "$6" "$3" "$MIN_DATE" "$5"
         fi
     elif [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${VALIDATION}" = "TRUE" ]; then
-        ${PRINTF} "%-35s %-35s %-32s %-17s\n" "$1:$2" "$7" "$8" "$6"
-
+        if [ "${CSV}" = "TRUE" ]; then
+            ${PRINTF} '"%s","%s","%s","%s","%s","%s","%s","%d"\n' "$1" "$7" "$9" "$8" "$6" "$3" "$4" "$5"
+        else
+            ${PRINTF} "%-35s %-35s %-32s %-17s\n" "$1:$2" "$7" "$8" "$6"
+        fi
     elif [ "${QUIET}" != "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]; then
         MIN_DATE=$(echo "$4" | "${AWK}" '{ printf "%3s %2d, %4d", $1, $2, $4 }')
         if [ "${NAGIOS}" = "TRUE" ]; then
             ${PRINTF} "%-47s %-12s %-12s %s\n" "$1:$2" "$3" "$MIN_DATE" "|days=$5"
+        elif [ "${CSV}" = "TRUE" ]; then
+            ${PRINTF} '"%s","%s","%s",%4d\n' "$1:$2" "$3" "$MIN_DATE" "$5"
         else
             ${PRINTF} "%-47s %-12s %-12s %4d\n" "$1:$2" "$3" "$MIN_DATE" "$5"
         fi
     elif [ "${QUIET}" != "TRUE" ] && [ "${VALIDATION}" = "TRUE" ]; then
-        ${PRINTF} "%-35s %-35s %-32s\n" "$1:$2" "$7" "$8"
+        if [ "${CSV}" = "TRUE" ]; then
+            ${PRINTF} '"%s","%s","%s"\n' "$1:$2" "$7" "$8"
+        else
+            ${PRINTF} "%-35s %-35s %-32s\n" "$1:$2" "$7" "$8"
+        fi
     fi
 }
 
@@ -308,20 +334,33 @@ print_heading()
 {
     if [ "${NOHEADER}" != "TRUE" ]; then
         if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]; then
-            ${PRINTF} "\n%-35s %-17s %-8s %-11s %-4s\n" "Host" "Issuer" "Status" "Expires" "Days"
-            echo "----------------------------------- ----------------- -------- ----------- ----"
-
+            if [ "${CSV}" != "TRUE" ]; then
+                ${PRINTF} "\n%-35s %-17s %-8s %-11s %-4s\n" "Host" "Issuer" "Status" "Expires" "Days"
+                echo "----------------------------------- ----------------- -------- ----------- ----"
+            else
+                ${PRINTF} '"%s","%s","%s","%s","%s"\n' "Host" "Issuer" "Status" "Expires" "Days"
+            fi
         elif [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" = "TRUE" ]; then
-            ${PRINTF} "\n%-35s %-35s %-32s %-17s\n" "Host" "Common Name" "Serial #" "Issuer"
-            echo "----------------------------------- ----------------------------------- -------------------------------- -----------------"
-
+            if [ "${CSV}" != "TRUE" ]; then
+                ${PRINTF} "\n%-35s %-35s %-32s %-17s\n" "Host" "Common Name" "Serial #" "Issuer"
+                echo "----------------------------------- ----------------------------------- -------------------------------- -----------------"
+            else
+                ${PRINTF} '"%s","%s","%s","%s","%s","%s","%s","%s"\n' "Host" "Common Name" "Subject Alternative Name" "Serial #" "Issuer" "Status" "Expires" "Days"
+            fi
         elif [ "${QUIET}" != "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]; then
-            ${PRINTF} "\n%-47s %-12s %-12s %-4s\n" "Host" "Status" "Expires" "Days"
-            echo "----------------------------------------------- ------------ ------------ ----"
-
+            if [ "${CSV}" != "TRUE" ]; then
+                ${PRINTF} "\n%-47s %-12s %-12s %-4s\n" "Host" "Status" "Expires" "Days"
+                echo "----------------------------------------------- ------------ ------------ ----"
+            else
+                ${PRINTF} "%s,%s,%s,%s\n" "Host" "Status" "Expires" "Days"
+            fi
         elif [ "${QUIET}" != "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" = "TRUE" ]; then
-            ${PRINTF} "\n%-35s %-35s %-32s\n" "Host" "Common Name" "Serial #"
-            echo "----------------------------------- ----------------------------------- --------------------------------"
+            if [ "${CSV}" != "TRUE" ]; then
+                ${PRINTF} "\n%-35s %-35s %-32s\n" "Host" "Common Name" "Serial #"
+                echo "----------------------------------- ----------------------------------- --------------------------------"
+            else
+                ${PRINTF} "%s,%s,%s\n" "Host" "Common Name" "Serial #"
+            fi
         fi
     fi
 }
@@ -395,12 +434,13 @@ set_summary()
 ##########################################
 usage()
 {
-    echo "Usage: $0 [ -e email address ] [-E sender email address] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v]"
+    echo "Usage: $0 [ -e email address ] [-E sender email address] [ -x days ] [ -X secs ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v]"
     echo "       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }"
     echo ""
     echo "  -a                : Send a warning message through E-mail"
     echo "  -b                : Will not print header"
     echo "  -c cert file      : Print the expiration date for the PEM or PKCS12 formatted certificate in cert file"
+    echo "  -C                : CSV output"
     echo "  -d cert directory : Print the expiration date for the PEM or PKCS12 formatted certificates in cert directory"
     echo "  -e E-mail address : E-mail address to send expiration notices"
     echo "  -E E-mail sender  : E-mail address of the sender"
@@ -417,6 +457,7 @@ usage()
     echo "  -t type           : Specify the certificate type"
     echo "  -V                : Print version information"
     echo "  -x days           : Certificate expiration interval (eg. if cert_date < days)"
+    echo "  -X secs           : openssl timeout period in seconds"
     echo ""
 }
 
@@ -454,8 +495,11 @@ check_server_status() {
         OPTIONS="-connect ${1}:${2} -servername ${1} $TLSFLAG"
     fi
 
-    echo "" | "${OPENSSL}" s_client $OPTIONS 2> "${ERROR_TMP}" 1> "${CERT_TMP}"
-
+    if [ "${TIMEOUTSECS}" ]; then
+        echo "" | "${TIMEOUT}" "${TIMEOUTSECS}" "${OPENSSL}" s_client $OPTIONS 2> "${ERROR_TMP}" 1> "${CERT_TMP}"
+    else
+        echo "" | "${OPENSSL}" s_client $OPTIONS 2> "${ERROR_TMP}" 1> "${CERT_TMP}"
+    fi
     if "${GREP}" -i "Connection refused" "${ERROR_TMP}" > /dev/null; then
         prints "${1}" "${2}" "Connection refused" "Unknown"
         set_returncode 3
@@ -471,7 +515,7 @@ check_server_status() {
     elif "${GREP}" -i "ssl handshake failure" "${ERROR_TMP}" > /dev/null; then
         prints "${1}" "${2}" "SSL handshake failed" "Unknown"
         set_returncode 3
-    elif "${GREP}" -i "connect: Connection timed out" "${ERROR_TMP}" > /dev/null; then
+    elif "${GREP}" -i "connect:Connection timed out" "${ERROR_TMP}" > /dev/null; then
         prints "${1}" "${2}" "Connection timed out" "Unknown"
         set_returncode 3
     elif "${GREP}" -i "Name or service not known" "${ERROR_TMP}" > /dev/null; then
@@ -497,8 +541,7 @@ check_file_status() {
 
     ### Check to make sure the certificate file exists
     if [ ! -r "${CERTFILE}" ] || [ ! -s "${CERTFILE}" ]; then
-        echo "ERROR: The file named ${CERTFILE} is unreadable or doesn't exist"
-        echo "ERROR: Please check to make sure the certificate for ${HOST}:${PORT} is valid"
+        prints "$HOST" "$PORT" "Connection timed out" "Unknown" "0" "Unknown" "Unknown" "Unknown" "Unknown"
         set_returncode 3
         return
     fi
@@ -516,13 +559,17 @@ check_file_status() {
 
         # Extract the issuer from the certificate
         CERTISSUER=$("${OPENSSL}" x509 -in "${CERT_TMP}" -issuer -noout | \
-                     "${AWK}" 'BEGIN {RS=", " } $0 ~ /^O =/
-                                 { print substr($0,5,17)}')
+                    "${SED}" 's/.*CN=//')
 
         ### Grab the common name (CN) from the X.509 certificate
         COMMONNAME=$("${OPENSSL}" x509 -in "${CERT_TMP}" -subject -noout | \
-                     "${SED}" -e 's/.*CN = //' | \
-                     "${SED}" -e 's/, .*//')
+                    "${SED}" -e 's/.*CN *= *//' | \
+                    "${SED}" -e 's/, .*//')
+
+        # Grab the subject alternative name from the certificate
+        SUBJALTNAME=$("${OPENSSL}" x509 -in "${CERT_TMP}" -text -noout | \
+                    "${GREP}" 'DNS:' | \
+                    "${SED}" -e 's/^ *//')
 
         ### Grab the serial number from the X.509 certificate
         SERIAL=$("${OPENSSL}" x509 -in "${CERT_TMP}" -serial -noout | \
@@ -534,12 +581,17 @@ check_file_status() {
 
         # Extract the issuer from the certificate
         CERTISSUER=$("${OPENSSL}" x509 -in "${CERTFILE}" -issuer -noout -inform "${CERTTYPE}" | \
-                     "${AWK}" 'BEGIN {RS=", " } $0 ~ /^O =/ { print substr($0,5,17)}')
+                    "${SED}" 's/.*CN=//')
 
         ### Grab the common name (CN) from the X.509 certificate
         COMMONNAME=$("${OPENSSL}" x509 -in "${CERTFILE}" -subject -noout -inform "${CERTTYPE}" | \
-                     "${SED}" -e 's/.*CN = //' | \
-                     "${SED}" -e 's/, .*//')
+                    "${SED}" -e 's/.*CN *= *//' | \
+                    "${SED}" -e 's/, .*//')
+
+        # Grab the subject alternative name from the certificate
+        SUBJALTNAME=$("${OPENSSL}" x509 -in "${CERT_TMP}" -text -noout -inform "${CERTTYPE}" | \
+                    "${GREP}" 'DNS:' | \
+                    "${SED}" -e 's/^ *//')
 
         ### Grab the serial number from the X.509 certificate
         SERIAL=$("${OPENSSL}" x509 -in "${CERTFILE}" -serial -noout -inform "${CERTTYPE}" | \
@@ -553,6 +605,7 @@ check_file_status() {
     # Convert the date to seconds, and get the diff between NOW and the expiration date
     CERTJULIAN=$(date2julian "${MONTH#0}" "${2#0}" "${4}")
     CERTDIFF=$(date_diff "${NOWJULIAN}" "${CERTJULIAN}")
+    CERTSTATUS="Valid"
 
     if [ "${CERTDIFF}" -lt 0 ]; then
         if [ "${ALARM}" = "TRUE" ]; then
@@ -560,7 +613,7 @@ check_file_status() {
                 "The SSL certificate for ${HOST} \"(CN: ${COMMONNAME})\" has expired!"
         fi
 
-        prints "${HOST}" "${PORT}" "Expired" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
+        CERTSTATUS="Expired"
         RETCODE_LOCAL=2
 
     elif [ "${CERTDIFF}" -lt "${WARNDAYS}" ]; then
@@ -568,14 +621,22 @@ check_file_status() {
             send_mail "${SENDER}" "${ADMIN}" "Certificate for ${HOST} \"(CN: ${COMMONNAME})\" will expire in ${CERTDIFF} days or less" \
                 "The SSL certificate for ${HOST} \"(CN: ${COMMONNAME})\" will expire on ${CERTDATE}"
         fi
-        prints "${HOST}" "${PORT}" "Expiring" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
+        CERTSTATUS="Expiring"
         RETCODE_LOCAL=1
 
+    elif [ "${HOST}" != ${COMMONNAME} ]; then
+        SITETOPLEVEL=$(echo "${HOST}" | "${SED}" -e 's/[a-z0-9]*\./\*\./I')
+        if [[ "${SUBJALTNAME}" =~ "${SITETOPLEVEL}" ]]; then
+            CERTSTATUS="Valid (Wildcard)"
+            RETCODE_LOCAL=0
+        else 
+            CERTSTATUS="CN Mismatch"
+            RETCODE_LOCAL=3
+        fi
     else
-        prints "${HOST}" "${PORT}" "Valid" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}"
         RETCODE_LOCAL=0
     fi
-
+    prints "${HOST}" "${PORT}" "${CERTSTATUS}" "${CERTDATE}" "${CERTDIFF}" "${CERTISSUER}" "${COMMONNAME}" "${SERIAL}" "${SUBJALTNAME}"
     set_returncode "${RETCODE_LOCAL}"
     MIN_DATE=$(echo "${CERTDATE}" | "${AWK}" '{ print $1, $2, $4 }')
     set_summary "${RETCODE_LOCAL}" "${HOST}" "${PORT}" "${MIN_DATE}" "${CERTDIFF}"
@@ -584,12 +645,13 @@ check_file_status() {
 #################################
 ### Start of main program
 #################################
-while getopts abc:d:e:E:f:hik:nNp:qs:St:Vx: option
+while getopts abc:Cd:e:E:f:hik:nNp:qs:St:Vx:X: option
 do
     case "${option}" in
         a) ALARM="TRUE";;
         b) NOHEADER="TRUE";;
         c) CERTFILE=${OPTARG};;
+        C) CSV="TRUE";;
         d) CERTDIRECTORY=${OPTARG};;
         e) ADMIN=${OPTARG};;
         E) SENDER=${OPTARG};;
@@ -610,6 +672,7 @@ do
            exit 0
         ;;
         x) WARNDAYS=$OPTARG;;
+        X) TIMEOUTSECS=$OPTARG;;
        \?) usage
            exit 1;;
     esac
@@ -697,13 +760,13 @@ elif [ -f "${SERVERFILE}" ]; then
     IFS=$'\n'
     for LINE in $(grep -E -v '(^#|^$)' "${SERVERFILE}")
     do
-        HOST=${LINE%% *}
-        PORT=${LINE##* }
+        HOST=${LINE%%:*}
+        PORT=${LINE##*:}
         IFS=" "
-        if [ "$PORT" = "FILE" ]; then
-            check_file_status "${HOST}" "FILE" "${HOST}"
+        if [ "$PORT" = "$HOST" ]; then
+            check_server_status "${HOST}" "443"
         else
-            check_server_status "${HOST}" "${PORT}"
+            check_server_status "${HOST}" "${PORT:=443}"
         fi
     done
     IFS="${OLDIFS}"


### PR DESCRIPTION
The original code is abandonware, so implementing some changes suggested by other users and additions specifically to aid use of the tool by the Foundation.