### PR TITLE
Some server file fixes

### DIFF
--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -16,6 +16,7 @@ PROGRAMVERSION=5.0
 # Unreleased
 #  - Fix '-f', '-c', und '-d' options without '-s', but HOST environment
 #    variable defined - Herbert Graeber
+#  - Allow process substitution for '-s' option -- Herbert Graeber
 #
 # Version 5.0
 #  - Cleanup shellcheck findings
@@ -1036,7 +1037,7 @@ fi
 ### If a file is passed to the "-f" option on the command line, check
 ### each certificate or server / port combination in the file to see if
 ### they are about to expire
-if [ -f "${SERVERFILE}" ]; then
+if [ -n "${SERVERFILE}" ]; then
     print_heading
 
     if [ ! -r "${SERVERFILE}" ]; then
@@ -1062,13 +1063,13 @@ if [ -f "${SERVERFILE}" ]; then
     fi
     print_summary
 ### Check to see if the certificate in CERTFILE is about to expire
-elif [ "${CERTFILE}" != "" ]; then
+elif [ -n "${CERTFILE}" ]; then
     print_heading
     check_file_status "${CERTFILE}" "FILE" "${CERTFILE}"
     print_summary
 
 ### Check to see if the certificates in CERTDIRECTORY are about to expire
-elif [ "${CERTDIRECTORY}" != "" ]; then
+elif [ -n "${CERTDIRECTORY}" ] && ("${FIND}" -L "${CERTDIRECTORY}" -type f > /dev/null 2>&1); then
     print_heading
     if ! "${FIND}" -L "${CERTDIRECTORY}" -type f > /dev/null 2>&1; then
         report_unknown "DIRECTORY" "${CERTDIRECTORY}" "Unable to read directory"
@@ -1079,7 +1080,7 @@ elif [ "${CERTDIRECTORY}" != "" ]; then
     fi
     print_summary
 ### If a HOST was passed on the cmdline, use that value
-elif [ "${HOST}" != "" ]; then
+elif [ -n "${HOST}" ]; then
     print_heading
     check_server_status "${HOST}" "${PORT:=443}"
     print_summary

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -13,6 +13,10 @@ PROGRAMVERSION=5.0
 #
 # Revision History:
 #
+# Unreleased
+#  - Fix '-f', '-c', und '-d' options without '-s', but HOST environment
+#    variable defined - Herbert Graeber
+#
 # Version 5.0
 #  - Cleanup shellcheck findings
 #  - Fix a number of edge cases 
@@ -1029,15 +1033,10 @@ else
     exit 1
 fi
 
-### If a HOST was passed on the cmdline, use that value
-if [ "${HOST}" != "" ]; then
-    print_heading
-    check_server_status "${HOST}" "${PORT:=443}"
-    print_summary
 ### If a file is passed to the "-f" option on the command line, check
 ### each certificate or server / port combination in the file to see if
 ### they are about to expire
-elif [ "${SERVERFILE}" != "" ]; then
+if [ -f "${SERVERFILE}" ]; then
     print_heading
 
     if [ ! -r "${SERVERFILE}" ]; then
@@ -1078,6 +1077,11 @@ elif [ "${CERTDIRECTORY}" != "" ]; then
             check_file_status "${FILE}" "FILE" "${FILE}"
         done < <("${FIND}" -L "${CERTDIRECTORY}" -type f -print0)
     fi
+    print_summary
+### If a HOST was passed on the cmdline, use that value
+elif [ "${HOST}" != "" ]; then
+    print_heading
+    check_server_status "${HOST}" "${PORT:=443}"
     print_summary
 ### There was an error, so print a detailed usage message and exit
 else


### PR DESCRIPTION
This fixes some issues with `-f serverfile`:

- It makes the `-f serverfile` option work when the HOST environment variable is set (#94). OpenSUSE systems have `HOST` set per default. There is another pull request (#129), which disables HOST completely. Here the use of a HOST environ variable is treated as feature and is still functional, as long as none of `-s serverfile`, `-c certfile` or `-d cert directory` is used. 
- It makes `-f serverfile` work with process substitution (#123)
