### PR TITLE
Upgrade to v5.0: fix bugs, add features, improve code quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,37 @@
 # SSL Certification Expiration Checker:
 
-ssl-cert-check is a Bourne shell script that can be used to report on expiring SSL certificates. The script was designed to be run from cron and can e-mail warnings or log alerts through nagios.  
+ssl-cert-check is a Bourne shell script that can be used to report on expiring SSL certificates. The script was designed to be run from cron and can e-mail warnings or log alerts through nagios.
 
 # Usage:
 <pre>
 $ ./ssl-cert-check
-Usage: ./ssl-cert-check [ -e email address ] [ -E sender email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v]
+Usage: ./ssl-cert-check [ -e email address ] [ -E sender email address ] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v version]
+       [-C] [-j] [-T timeout] [-K]
        { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }"
 
   -a                : Send a warning message through E-mail
   -b                : Will not print header
   -c cert file      : Print the expiration date for the PEM or PKCS12 formatted certificate in cert file
+  -C                : Enable color output for terminal
   -d cert directory : Print the expiration date for the PEM or PKCS12 formatted certificates in cert directory
   -e E-mail address : E-mail address to send expiration notices
   -E E-mail address : Sender E-mail address
   -f cert file      : File with a list of FQDNs and ports
   -h                : Print this screen
   -i                : Print the issuer of the certificate
+  -j                : Output results in JSON format
   -k password       : PKCS12 file password
+  -K                : Read PKCS12 password from stdin (more secure than -k)
   -n                : Run as a Nagios plugin
   -N                : Run as a Nagios plugin and output one line summary (implies -n, requires -f or -d)
   -p port           : Port to connect to (interactive mode)
-  -s commmon name   : Server to connect to (interactive mode)
+  -s common name    : Server to connect to (interactive mode)
   -t type           : Specify the certificate type
   -q                : Don't print anything on the console
-  -v                : Specify a specific protocol version to use (tls, ssl2, ssl3)
-  -V                : Only print validation data
+  -S                : Print validation information
+  -T timeout        : Connection timeout in seconds (default: 30)
+  -v version        : TLS version to use (ssl2, ssl3, tls1, tls1_1, tls1_2, tls1_3)
+  -V                : Print version information
   -x days           : Certificate expiration interval (eg. if cert_date < days)
 </pre>
 
@@ -50,9 +56,22 @@ Check all certificates with file pattern "/etc/haproxy/ssl/\*.pem"
 $ ssl-cert-check -d "/etc/haproxy/ssl/*.pem"
 Host                                            Status       Expires      Days
 ----------------------------------------------- ------------ ------------ ----
-FILE:/etc/haproxy/ssl/example1.org.pem      Valid        Jan 6 2017   78                                 
-FILE:/etc/haproxy/ssl/example2.org.pem      Valid        Jan 1 2017   73                                 
-FILE:/etc/haproxy/ssl/example3.org.pem      Valid        Jan 6 2017   78                                 
+FILE:/etc/haproxy/ssl/example1.org.pem      Valid        Jan 6 2017   78
+FILE:/etc/haproxy/ssl/example2.org.pem      Valid        Jan 1 2017   73
+FILE:/etc/haproxy/ssl/example3.org.pem      Valid        Jan 6 2017   78
+</pre>
+
+Output results in JSON format:
+
+<pre>
+$ ssl-cert-check -s gmail.google.com -p 443 -j
+[{"host":"gmail.google.com","port":"443","status":"Valid","expires":"...","days_left":365,"issuer":"...","common_name":"...","serial":"..."}]
+</pre>
+
+Use color output for quick visual scanning:
+
+<pre>
+$ ssl-cert-check -f ssldomains -C
 </pre>
 
 Send an e-mail to admin@prefetch.net if a domain listed in ssldomains will expire in the next 60-days:

--- a/ssl-cert-check
+++ b/ssl-cert-check
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-PROGRAMVERSION=4.14
+PROGRAMVERSION=5.0
 #
 # Program: SSL Certificate Check <ssl-cert-check>
 #
@@ -9,9 +9,24 @@ PROGRAMVERSION=4.14
 #
 # Author: Matty < matty at prefetch dot net >
 #
-# Last Updated: 11-12-2020
+# Last Updated: 02-26-2026
 #
 # Revision History:
+#
+# Version 5.0
+#  - Fixed OLDIFS never being saved before IFS modification
+#  - Fixed quoted wildcard in send_mail case default (never matched)
+#  - Converted OPTIONS to bash array (as recommended since v4.10)
+#  - Fixed find output word splitting on filenames with spaces
+#  - Restored missing -v option for TLS version selection
+#  - Fixed unquoted variables throughout (shellcheck compliance)
+#  - Fixed typos (commmon, ceriticate)
+#  - Refactored certificate info extraction to eliminate code duplication
+#  - Added connection timeout option (-T)
+#  - Added JSON output option (-j)
+#  - Added color output option (-C)
+#  - Added PKCS12 password via stdin option (-K)
+#  - Use system temp directory instead of hardcoded /var/tmp
 #
 # Version 4.14
 #  - Fixed HOST / PORT discovery @mhow2
@@ -308,8 +323,31 @@ NAGIOSSUMMARY="FALSE"
 # NULL out the PKCSDBPASSWD variable for later use (cmdline: -k)
 PKCSDBPASSWD=""
 
+# Read PKCS12 password from stdin (cmdline: -K)
+PKCSDBPASSWD_STDIN="FALSE"
+
 # Type of certificate (PEM, DER, NET) (cmdline: -t)
 CERTTYPE="pem"
+
+# TLS protocol version (cmdline: -v)
+TLSVERSION=""
+
+# Connection timeout in seconds (cmdline: -T)
+TIMEOUT=30
+
+# Output in JSON format (cmdline: -j)
+JSONOUTPUT="FALSE"
+JSONRESULTS=""
+JSONFIRST="TRUE"
+
+# Color output (cmdline: -C)
+COLOROUTPUT="FALSE"
+
+# ANSI color codes
+COLOR_RED='\033[0;31m'
+COLOR_GREEN='\033[0;32m'
+COLOR_YELLOW='\033[1;33m'
+COLOR_NC='\033[0m'
 
 # Location of system binaries
 AWK=$(command -v awk)
@@ -371,7 +409,7 @@ cleanup() {
     fi
 
     if [ -f "${ERROR_TMP}" ]; then
-     rm -f "${ERROR_TMP}"
+        rm -f "${ERROR_TMP}"
     fi
 }
 
@@ -401,7 +439,7 @@ send_mail() {
         "sendmail")
             (echo "Subject:$SUBJECT" && echo "TO:$TO" && echo "FROM:$FROM" && echo "$MSG") | "${MAIL}" "$TO"
             ;;
-        "*")
+        *)
             echo "ERROR: You enabled automated alerts, but the mail binary could not be found."
             echo "FIX: Please modify the \${MAIL} and \${MAILMODE} variable in the program header."
             exit 1
@@ -446,7 +484,7 @@ date2julian() {
 #############################################################################
 getmonth()
 {
-    case ${1} in
+    case "${1}" in
         Jan) echo 1 ;;
         Feb) echo 2 ;;
         Mar) echo 3 ;;
@@ -479,6 +517,39 @@ date_diff()
 }
 
 #####################################################################
+# Purpose: Accumulate a JSON result entry
+# Arguments:
+#   $1 -> Hostname
+#   $2 -> TCP Port
+#   $3 -> Status of certification (e.g., expired or valid)
+#   $4 -> Date when certificate will expire
+#   $5 -> Days left until the certificate will expire
+#   $6 -> Issuer of the certificate
+#   $7 -> Common Name
+#   $8 -> Serial Number
+#####################################################################
+prints_json()
+{
+    local host="${1}" port="${2}" status="${3}" expires="${4}" days="${5}"
+    local issuer="${6}" cn="${7}" serial="${8}"
+
+    if [ "${JSONFIRST}" = "TRUE" ]; then
+        JSONFIRST="FALSE"
+    else
+        JSONRESULTS="${JSONRESULTS},"
+    fi
+
+    # Escape double quotes and backslashes in values
+    host="${host//\\/\\\\}" ; host="${host//\"/\\\"}"
+    cn="${cn//\\/\\\\}" ; cn="${cn//\"/\\\"}"
+    issuer="${issuer//\\/\\\\}" ; issuer="${issuer//\"/\\\"}"
+    expires="${expires//\\/\\\\}" ; expires="${expires//\"/\\\"}"
+    serial="${serial//\\/\\\\}" ; serial="${serial//\"/\\\"}"
+
+    JSONRESULTS="${JSONRESULTS}{\"host\":\"${host}\",\"port\":\"${port}\",\"status\":\"${status}\",\"expires\":\"${expires}\",\"days_left\":${days:-0},\"issuer\":\"${issuer}\",\"common_name\":\"${cn}\",\"serial\":\"${serial}\"}"
+}
+
+#####################################################################
 # Purpose: Print a line with the expiraton interval
 # Arguments:
 #   $1 -> Hostname
@@ -492,14 +563,32 @@ date_diff()
 #####################################################################
 prints()
 {
+    if [ "${JSONOUTPUT}" = "TRUE" ]; then
+        prints_json "$@"
+        return
+    fi
+
     if [ "${NAGIOSSUMMARY}" = "TRUE" ]; then
         return
+    fi
+
+    # Apply color to status if enabled
+    local status_display="${3}"
+    local status_width=12
+    if [ "${COLOROUTPUT}" = "TRUE" ]; then
+        case "${3}" in
+            Valid)    status_display="${COLOR_GREEN}${3}${COLOR_NC}" ; status_width=25 ;;
+            Expiring) status_display="${COLOR_YELLOW}${3}${COLOR_NC}" ; status_width=25 ;;
+            Expired)  status_display="${COLOR_RED}${3}${COLOR_NC}" ; status_width=25 ;;
+        esac
     fi
 
     if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]; then
         MIN_DATE=$(echo "$4" | "${AWK}" '{ printf "%3s %2d %4d", $1, $2, $4 }')
         if [ "${NAGIOS}" = "TRUE" ]; then
             ${PRINTF} "%-35s %-17s %-8s %-11s %s\n" "$1:$2" "$6" "$3" "$MIN_DATE" "|days=$5"
+        elif [ "${COLOROUTPUT}" = "TRUE" ]; then
+            ${PRINTF} "%-35s %-17s %-${status_width}b %-11s %4d\n" "$1:$2" "$6" "$status_display" "$MIN_DATE" "$5"
         else
             ${PRINTF} "%-35s %-17s %-8s %-11s %4d\n" "$1:$2" "$6" "$3" "$MIN_DATE" "$5"
         fi
@@ -510,6 +599,8 @@ prints()
         MIN_DATE=$(echo "$4" | "${AWK}" '{ printf "%3s %2d, %4d", $1, $2, $4 }')
         if [ "${NAGIOS}" = "TRUE" ]; then
             ${PRINTF} "%-47s %-12s %-12s %s\n" "$1:$2" "$3" "$MIN_DATE" "|days=$5"
+        elif [ "${COLOROUTPUT}" = "TRUE" ]; then
+            ${PRINTF} "%-47s %-${status_width}b %-12s %4d\n" "$1:$2" "$status_display" "$MIN_DATE" "$5"
         else
             ${PRINTF} "%-47s %-12s %-12s %4d\n" "$1:$2" "$3" "$MIN_DATE" "$5"
         fi
@@ -526,6 +617,10 @@ prints()
 ####################################################
 print_heading()
 {
+    if [ "${JSONOUTPUT}" = "TRUE" ]; then
+        return
+    fi
+
     if [ "${NOHEADER}" != "TRUE" ]; then
         if [ "${QUIET}" != "TRUE" ] && [ "${ISSUER}" = "TRUE" ] && [ "${NAGIOS}" != "TRUE" ] && [ "${VALIDATION}" != "TRUE" ]; then
             ${PRINTF} "\n%-35s %-17s %-8s %-11s %-4s\n" "Host" "Issuer" "Status" "Expires" "Days"
@@ -557,22 +652,34 @@ print_summary()
         return
     fi
 
-    if [ ${SUMMARY_WILL_EXPIRE} -eq 0 ] && [ ${SUMMARY_EXPIRED} -eq 0 ]; then
+    if [ "${SUMMARY_WILL_EXPIRE}" -eq 0 ] && [ "${SUMMARY_EXPIRED}" -eq 0 ]; then
         ${PRINTF} "%s valid certificate(s)|days=%s\n" "${SUMMARY_VALID}" "${SUMMARY_MIN_DIFF}"
 
-    elif [ ${SUMMARY_EXPIRED} -ne 0 ]; then
+    elif [ "${SUMMARY_EXPIRED}" -ne 0 ]; then
         ${PRINTF} "%s certificate(s) expired (%s:%s on %s)|days=%s\n" "${SUMMARY_EXPIRED}" "${SUMMARY_MIN_HOST}" "${SUMMARY_MIN_PORT}" "${SUMMARY_MIN_DATE}" "${SUMMARY_MIN_DIFF}"
 
-    elif [ ${SUMMARY_WILL_EXPIRE} -ne 0 ]; then
+    elif [ "${SUMMARY_WILL_EXPIRE}" -ne 0 ]; then
         ${PRINTF} "%s certificate(s) will expire (%s:%s on %s)|days=%s\n" "${SUMMARY_WILL_EXPIRE}" "${SUMMARY_MIN_HOST}" "${SUMMARY_MIN_PORT}" "${SUMMARY_MIN_DATE}" "${SUMMARY_MIN_DIFF}"
 
+    fi
+}
+
+####################################################
+# Purpose: Print final JSON output
+# Arguments:
+#   None
+####################################################
+print_json_output()
+{
+    if [ "${JSONOUTPUT}" = "TRUE" ]; then
+        echo "[${JSONRESULTS}]"
     fi
 }
 
 #############################################################
 # Purpose: Set returncode to value if current value is lower
 # Arguments:
-#   $1 -> New returncorde
+#   $1 -> New returncode
 #############################################################
 set_returncode()
 {
@@ -615,26 +722,32 @@ set_summary()
 ##########################################
 usage()
 {
-    echo "Usage: $0 [ -e email address ] [-E sender email address] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v]"
+    echo "Usage: $0 [ -e email address ] [-E sender email address] [ -x days ] [-q] [-a] [-b] [-h] [-i] [-n] [-N] [-v version]"
+    echo "       [-C] [-j] [-T timeout] [-K]"
     echo "       { [ -s common_name ] && [ -p port] } || { [ -f cert_file ] } || { [ -c cert file ] } || { [ -d cert dir ] }"
     echo ""
     echo "  -a                : Send a warning message through E-mail"
     echo "  -b                : Will not print header"
     echo "  -c cert file      : Print the expiration date for the PEM or PKCS12 formatted certificate in cert file"
+    echo "  -C                : Enable color output for terminal"
     echo "  -d cert directory : Print the expiration date for the PEM or PKCS12 formatted certificates in cert directory"
     echo "  -e E-mail address : E-mail address to send expiration notices"
     echo "  -E E-mail sender  : E-mail address of the sender"
     echo "  -f cert file      : File with a list of FQDNs and ports"
     echo "  -h                : Print this screen"
     echo "  -i                : Print the issuer of the certificate"
+    echo "  -j                : Output results in JSON format"
     echo "  -k password       : PKCS12 file password"
+    echo "  -K                : Read PKCS12 password from stdin (more secure than -k)"
     echo "  -n                : Run as a Nagios plugin"
     echo "  -N                : Run as a Nagios plugin and output one line summary (implies -n, requires -f or -d)"
     echo "  -p port           : Port to connect to (interactive mode)"
     echo "  -q                : Don't print anything on the console"
-    echo "  -s commmon name   : Server to connect to (interactive mode)"
+    echo "  -s common name    : Server to connect to (interactive mode)"
     echo "  -S                : Print validation information"
     echo "  -t type           : Specify the certificate type"
+    echo "  -T timeout        : Connection timeout in seconds (default: 30)"
+    echo "  -v version        : TLS version to use (ssl2, ssl3, tls1, tls1_1, tls1_2, tls1_3)"
     echo "  -V                : Print version information"
     echo "  -x days           : Certificate expiration interval (eg. if cert_date < days)"
     echo ""
@@ -651,30 +764,47 @@ usage()
 check_server_status() {
 
     PORT="$2"
+
+    # Determine STARTTLS protocol based on port
+    local STARTTLS_PROTO=""
     case "$PORT" in
-        smtp|25|submission|587) TLSFLAG="-starttls smtp";;
-        pop3|110)               TLSFLAG="-starttls pop3";;
-        imap|143)               TLSFLAG="-starttls imap";;
-        ftp|21)                 TLSFLAG="-starttls ftp";;
-        xmpp|5222)              TLSFLAG="-starttls xmpp";;
-        xmpp-server|5269)       TLSFLAG="-starttls xmpp-server";;
-        irc|194)                TLSFLAG="-starttls irc";;
-        postgres|5432)          TLSFLAG="-starttls postgres";;
-        mysql|3306)             TLSFLAG="-starttls mysql";;
-        lmtp|24)                TLSFLAG="-starttls lmtp";;
-        nntp|119)               TLSFLAG="-starttls nntp";;
-        sieve|4190)             TLSFLAG="-starttls sieve";;
-        ldap|389)               TLSFLAG="-starttls ldap";;
-        *)                      TLSFLAG="";;
+        smtp|25|submission|587) STARTTLS_PROTO="smtp";;
+        pop3|110)               STARTTLS_PROTO="pop3";;
+        imap|143)               STARTTLS_PROTO="imap";;
+        ftp|21)                 STARTTLS_PROTO="ftp";;
+        xmpp|5222)              STARTTLS_PROTO="xmpp";;
+        xmpp-server|5269)       STARTTLS_PROTO="xmpp-server";;
+        irc|194)                STARTTLS_PROTO="irc";;
+        postgres|5432)          STARTTLS_PROTO="postgres";;
+        mysql|3306)             STARTTLS_PROTO="mysql";;
+        lmtp|24)                STARTTLS_PROTO="lmtp";;
+        nntp|119)               STARTTLS_PROTO="nntp";;
+        sieve|4190)             STARTTLS_PROTO="sieve";;
+        ldap|389)               STARTTLS_PROTO="ldap";;
+        *)                      STARTTLS_PROTO="";;
     esac
 
-    if [ "${TLSSERVERNAME}" = "FALSE" ]; then
-        OPTIONS="-connect ${1}:${2} $TLSFLAG"
-    else
-        OPTIONS="-connect ${1}:${2} -servername ${1} $TLSFLAG"
+    # Build openssl options as an array to avoid word splitting issues
+    # See: http://mywiki.wooledge.org/BashFAQ/050
+    local OPTIONS=(-connect "${1}:${2}")
+
+    if [ "${TLSSERVERNAME}" != "FALSE" ]; then
+        OPTIONS+=(-servername "${1}")
     fi
 
-    echo "" | "${OPENSSL}" s_client $OPTIONS 2> "${ERROR_TMP}" 1> "${CERT_TMP}"
+    if [ -n "${STARTTLS_PROTO}" ]; then
+        OPTIONS+=(-starttls "${STARTTLS_PROTO}")
+    fi
+
+    if [ -n "${TLSVERSION}" ]; then
+        OPTIONS+=("-${TLSVERSION}")
+    fi
+
+    if [ "${HAS_CONNECT_TIMEOUT}" = "TRUE" ]; then
+        OPTIONS+=(-connect_timeout "${TIMEOUT}")
+    fi
+
+    echo "" | "${OPENSSL}" s_client "${OPTIONS[@]}" 2> "${ERROR_TMP}" 1> "${CERT_TMP}"
 
     if "${GREP}" -i "Connection refused" "${ERROR_TMP}" > /dev/null; then
         prints "${1}" "${2}" "Connection refused" "Unknown"
@@ -703,6 +833,34 @@ check_server_status() {
 }
 
 #####################################################
+# Purpose: Extract certificate details from a cert file
+# Arguments:
+#   $1 -> Certificate file path
+#   $2 -> Certificate format type (optional, e.g., "pem", "der")
+#####################################################
+extract_cert_info() {
+    local cert_file="${1}"
+    local inform_args=()
+
+    if [ -n "${2}" ]; then
+        inform_args=(-inform "${2}")
+    fi
+
+    CERTDATE=$("${OPENSSL}" x509 -in "${cert_file}" -enddate -noout "${inform_args[@]}" | \
+               "${SED}" 's/notAfter\=//')
+
+    CERTISSUER=$("${OPENSSL}" x509 -in "${cert_file}" -issuer -noout "${inform_args[@]}" | \
+                 "${SED}" -e 's/.*[/,] *O *= *//' -e 's/\/.*//' -e 's/,.*//' | \
+                 cut -c 1-17)
+
+    COMMONNAME=$("${OPENSSL}" x509 -in "${cert_file}" -subject -noout "${inform_args[@]}" | \
+                 "${SED}" -e 's/.*CN *= *//' -e 's/, .*//' -e 's/\/.*//')
+
+    SERIAL=$("${OPENSSL}" x509 -in "${cert_file}" -serial -noout "${inform_args[@]}" | \
+             "${SED}" -e 's/serial=//')
+}
+
+#####################################################
 ### Check the expiration status of a certificate file
 ### Accepts three parameters:
 ###  $1 -> certificate file to process
@@ -727,46 +885,21 @@ check_file_status() {
     if [ "${PKCSDBPASSWD}" != "" ]; then
         # Extract the certificate from the PKCS#12 database, and
         # send the informational message to /dev/null
-        "${OPENSSL}" pkcs12 -nokeys -in "${CERTFILE}" \
-                   -out "${CERT_TMP}" -clcerts -password pass:"${PKCSDBPASSWD}" 2> /dev/null
+        if [ "${PKCSDBPASSWD_STDIN}" = "TRUE" ]; then
+            echo "${PKCSDBPASSWD}" | "${OPENSSL}" pkcs12 -nokeys -in "${CERTFILE}" \
+                       -out "${CERT_TMP}" -clcerts -passin stdin 2> /dev/null
+        else
+            "${OPENSSL}" pkcs12 -nokeys -in "${CERTFILE}" \
+                       -out "${CERT_TMP}" -clcerts -password pass:"${PKCSDBPASSWD}" 2> /dev/null
+        fi
 
-        # Extract the expiration date from the certificate
-        CERTDATE=$("${OPENSSL}" x509 -in "${CERT_TMP}" -enddate -noout | \
-                   "${SED}" 's/notAfter\=//')
-
-        # Extract the issuer from the certificate
-        CERTISSUER=$("${OPENSSL}" x509 -in "${CERT_TMP}" -issuer -noout | \
-                     "${AWK}" 'BEGIN {RS=", " } $0 ~ /^O =/
-                                 { print substr($0,5,17)}')
-
-        ### Grab the common name (CN) from the X.509 certificate
-        COMMONNAME=$("${OPENSSL}" x509 -in "${CERT_TMP}" -subject -noout | \
-                     "${SED}" -e 's/.*CN = //' | \
-                     "${SED}" -e 's/, .*//')
-
-        ### Grab the serial number from the X.509 certificate
-        SERIAL=$("${OPENSSL}" x509 -in "${CERT_TMP}" -serial -noout | \
-                 "${SED}" -e 's/serial=//')
+        extract_cert_info "${CERT_TMP}"
     else
-        # Extract the expiration date from the ceriticate
-        CERTDATE=$("${OPENSSL}" x509 -in "${CERTFILE}" -enddate -noout -inform "${CERTTYPE}" | \
-                   "${SED}" 's/notAfter\=//')
-
-        # Extract the issuer from the certificate
-        CERTISSUER=$("${OPENSSL}" x509 -in "${CERTFILE}" -issuer -noout -inform "${CERTTYPE}" | \
-                     "${AWK}" 'BEGIN {RS=", " } $0 ~ /^O =/ { print substr($0,5,17)}')
-
-        ### Grab the common name (CN) from the X.509 certificate
-        COMMONNAME=$("${OPENSSL}" x509 -in "${CERTFILE}" -subject -noout -inform "${CERTTYPE}" | \
-                     "${SED}" -e 's/.*CN = //' | \
-                     "${SED}" -e 's/, .*//')
-
-        ### Grab the serial number from the X.509 certificate
-        SERIAL=$("${OPENSSL}" x509 -in "${CERTFILE}" -serial -noout -inform "${CERTTYPE}" | \
-                 "${SED}" -e 's/serial=//')
+        extract_cert_info "${CERTFILE}" "${CERTTYPE}"
     fi
 
     ### Split the result into parameters, and pass the relevant pieces to date2julian
+    # Intentional word splitting on CERTDATE to extract month, day, time, year fields
     set -- ${CERTDATE}
     MONTH=$(getmonth "${1}")
 
@@ -804,36 +937,67 @@ check_file_status() {
 #################################
 ### Start of main program
 #################################
-while getopts abc:d:e:E:f:hik:nNp:qs:St:Vx: option
+while getopts abc:Cd:e:E:f:hijk:KnNp:qs:St:T:v:Vx: option
 do
     case "${option}" in
         a) ALARM="TRUE";;
         b) NOHEADER="TRUE";;
-        c) CERTFILE=${OPTARG};;
-        d) CERTDIRECTORY=${OPTARG};;
-        e) ADMIN=${OPTARG};;
-        E) SENDER=${OPTARG};;
-        f) SERVERFILE=$OPTARG;;
+        c) CERTFILE="${OPTARG}";;
+        C) COLOROUTPUT="TRUE";;
+        d) CERTDIRECTORY="${OPTARG}";;
+        e) ADMIN="${OPTARG}";;
+        E) SENDER="${OPTARG}";;
+        f) SERVERFILE="${OPTARG}";;
         h) usage
            exit 1;;
         i) ISSUER="TRUE";;
-        k) PKCSDBPASSWD=${OPTARG};;
+        j) JSONOUTPUT="TRUE";;
+        k) PKCSDBPASSWD="${OPTARG}"
+           echo "WARNING: Passing passwords via -k exposes them in process listings." >&2
+           echo "WARNING: Consider using -K to read the password from stdin." >&2
+           ;;
+        K) PKCSDBPASSWD_STDIN="TRUE";;
         n) NAGIOS="TRUE";;
         N) NAGIOS="TRUE"
            NAGIOSSUMMARY="TRUE";;
-        p) PORT=$OPTARG;;
+        p) PORT="${OPTARG}";;
         q) QUIET="TRUE";;
-        s) HOST=$OPTARG;;
+        s) HOST="${OPTARG}";;
         S) VALIDATION="TRUE";;
-        t) CERTTYPE=$OPTARG;;
+        t) CERTTYPE="${OPTARG}";;
+        T) TIMEOUT="${OPTARG}";;
+        v) TLSVERSION="${OPTARG}";;
         V) echo "${PROGRAMVERSION}"
            exit 0
         ;;
-        x) WARNDAYS=$OPTARG;;
+        x) WARNDAYS="${OPTARG}";;
        \?) usage
            exit 1;;
     esac
 done
+
+### Validate TLS version if specified
+if [ -n "${TLSVERSION}" ]; then
+    case "${TLSVERSION}" in
+        ssl2|ssl3|tls1|tls1_1|tls1_2|tls1_3) ;;
+        *)
+            echo "ERROR: Unknown TLS version '${TLSVERSION}'"
+            echo "Valid options: ssl2, ssl3, tls1, tls1_1, tls1_2, tls1_3"
+            exit 1
+            ;;
+    esac
+fi
+
+### Read PKCS12 password from stdin if -K was specified
+if [ "${PKCSDBPASSWD_STDIN}" = "TRUE" ] && [ -z "${PKCSDBPASSWD}" ]; then
+    read -r -s -p "Enter PKCS12 password: " PKCSDBPASSWD
+    echo >&2
+fi
+
+### Disable color output when stdout is not a terminal
+if [ "${COLOROUTPUT}" = "TRUE" ] && [ ! -t 1 ]; then
+    COLOROUTPUT="FALSE"
+fi
 
 ### Check to make sure a openssl utility is available
 if [ ! -f "${OPENSSL}" ]; then
@@ -870,7 +1034,7 @@ if [ ! -f "${SED}" ] || [ ! -f "${AWK}" ]; then
     exit 1
 fi
 
-### Check to make sure a mail client is available it automated notifications are requested
+### Check to make sure a mail client is available if automated notifications are requested
 if [ "${ALARM}" = "TRUE" ] && [ ! -f "${MAIL}" ]; then
     echo "ERROR: You enabled automated alerts, but the mail binary could not be found."
     echo "FIX: Please modify the ${MAIL} variable in the program header."
@@ -878,20 +1042,27 @@ if [ "${ALARM}" = "TRUE" ] && [ ! -f "${MAIL}" ]; then
 fi
 
 # Send along the servername when TLS is used
-if ${OPENSSL} s_client -help 2>&1 | grep '-servername' > /dev/null; then
+if "${OPENSSL}" s_client -help 2>&1 | "${GREP}" '-servername' > /dev/null; then
     TLSSERVERNAME="TRUE"
 else
     TLSSERVERNAME="FALSE"
 fi
 
+# Check if openssl supports -connect_timeout
+if "${OPENSSL}" s_client -help 2>&1 | "${GREP}" '-connect_timeout' > /dev/null; then
+    HAS_CONNECT_TIMEOUT="TRUE"
+else
+    HAS_CONNECT_TIMEOUT="FALSE"
+fi
+
 # Place to stash temporary files
-CERT_TMP=$($MKTEMP /var/tmp/cert.XXXXXX)
-ERROR_TMP=$($MKTEMP /var/tmp/error.XXXXXX)
+CERT_TMP=$("${MKTEMP}" "${TMPDIR:-/tmp}/cert.XXXXXX")
+ERROR_TMP=$("${MKTEMP}" "${TMPDIR:-/tmp}/error.XXXXXX")
 
 ### Baseline the dates so we have something to compare to
-MONTH=$(${DATE} "+%m")
-DAY=$(${DATE} "+%d")
-YEAR=$(${DATE} "+%Y")
+MONTH=$("${DATE}" "+%m")
+DAY=$("${DATE}" "+%d")
+YEAR=$("${DATE}" "+%Y")
 NOWJULIAN=$(date2julian "${MONTH#0}" "${DAY#0}" "${YEAR}")
 
 ### Touch the files prior to using them
@@ -907,6 +1078,7 @@ fi
 if [ "${HOST}" != "" ]; then
     print_heading
     check_server_status "${HOST}" "${PORT:=443}"
+    print_json_output
     print_summary
 ### If a file is passed to the "-f" option on the command line, check
 ### each certificate or server / port combination in the file to see if
@@ -914,11 +1086,12 @@ if [ "${HOST}" != "" ]; then
 elif [ -f "${SERVERFILE}" ]; then
     print_heading
 
+    OLDIFS="${IFS}"
     IFS=$'\n'
     for LINE in $(grep -E -v '(^#|^$)' "${SERVERFILE}")
     do
-        HOST=${LINE%% *}
-        PORT=${LINE##* }
+        HOST="${LINE%% *}"
+        PORT="${LINE##* }"
         IFS=" "
         if [ "$PORT" = "FILE" ]; then
             check_file_status "${HOST}" "FILE" "${HOST}"
@@ -927,19 +1100,22 @@ elif [ -f "${SERVERFILE}" ]; then
         fi
     done
     IFS="${OLDIFS}"
+    print_json_output
     print_summary
 ### Check to see if the certificate in CERTFILE is about to expire
 elif [ "${CERTFILE}" != "" ]; then
     print_heading
     check_file_status "${CERTFILE}" "FILE" "${CERTFILE}"
+    print_json_output
     print_summary
 
 ### Check to see if the certificates in CERTDIRECTORY are about to expire
 elif [ "${CERTDIRECTORY}" != "" ] && ("${FIND}" -L "${CERTDIRECTORY}" -type f > /dev/null 2>&1); then
     print_heading
-    for FILE in $("${FIND}" -L "${CERTDIRECTORY}" -type f); do
+    while IFS= read -r -d '' FILE; do
         check_file_status "${FILE}" "FILE" "${FILE}"
-    done
+    done < <("${FIND}" -L "${CERTDIRECTORY}" -type f -print0)
+    print_json_output
     print_summary
 ### There was an error, so print a detailed usage message and exit
 else


### PR DESCRIPTION
Fix 10 bugs: OLDIFS never saved, quoted wildcard in case default, unquoted OPTIONS string, find word splitting on spaces, missing -v option, unquoted variables, and typos. Refactor certificate info extraction into extract_cert_info() to eliminate duplication. Add connection timeout (-T), JSON output (-j), color output (-C), TLS version selection (-v), and secure PKCS12 password via stdin (-K). Fix issuer/CN parsing to support both LibreSSL and OpenSSL formats. Use system temp directory instead of hardcoded /var/tmp.